### PR TITLE
Updates seq of live changes in batched changes feeds

### DIFF
--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -212,11 +212,11 @@ const getChanges = feed => {
       }
 
       // Fixes race condition where a new doc is added while the changes feed is active,
-      // but our continuousFeed listener receives the change after the request has been sent.
-      // When receiving empty results, PouchDB considers replication complete and
-      // uses last_seq to write it's checkpointer doc.
-      // By not advancing the checkpointer seq when there are no results, we make sure this docs will be part of
-      // the next _changes response.
+      // but our continuousFeed listener receives the change after the response has been sent.
+      // When receiving empty results, PouchDB considers replication to be complete and
+      // uses reponse.last_seq to write it's checkpointer doc.
+      // By not advancing the checkpointer seq when there are no results, we make sure these docs will be retrieved
+      // in the next replication attempt.
       feed.lastSeq = results.length ? response.last_seq : feed.initSeq;
 
       generateTombstones(results);

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -217,7 +217,7 @@ const getChanges = feed => {
       // uses reponse.last_seq to write it's checkpointer doc.
       // By not advancing the checkpointer seq past our last change, we make sure these docs will be retrieved
       // in the next replication attempt.
-      feed.lastSeq = results.length ? results.slice(-1)[0].seq : feed.initSeq;
+      feed.lastSeq = results.length ? results[results.length - 1].seq : feed.currentSeq;
 
       generateTombstones(results);
       feed.results = results;
@@ -255,6 +255,7 @@ const initFeed = (req, res) => {
     res: res,
     initSeq: req.query && req.query.since || 0,
     lastSeq: req.query && req.query.since || currentSeq,
+    currentSeq: currentSeq,
     pendingChanges: [],
     results: [],
     limit: req.query && req.query.limit || config.get('changes_controller').changes_limit,

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -82,7 +82,7 @@ const generateResponse = feed => {
 };
 
 // any doc ID should only appear once in the changes feed, with a list of changed revs attached to it
-const appendChange = (results, changeObj, seq) => {
+const appendChange = (results, changeObj, forceSeq = false) => {
   const result = _.findWhere(results, { id: changeObj.id });
   if (!result) {
     const change = JSON.parse(JSON.stringify(changeObj.change));
@@ -95,8 +95,8 @@ const appendChange = (results, changeObj, seq) => {
     // to avoid the possibility of them being skipped.
     // Therefore, their seq is changed to equal the feed's last_seq to avoid PouchDB setting a Checkpointer
     // with a future seq and to use a correct seq when requesting the next batch of changes.
-    if (seq) {
-      change.seq = seq;
+    if (forceSeq) {
+      change.seq = forceSeq;
     }
 
     return results.push(change);
@@ -278,9 +278,6 @@ const initFeed = (req, res) => {
 
 const processRequest = (req, res) => {
   initFeed(req, res).then(getChanges);
-  /*initFeed(req, res).then(feed => {
-    setTimeout(() => getChanges(feed), 5000);
-  });*/
 };
 
 // restarts the request, refreshing user-settings

--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -377,11 +377,16 @@ const shouldLimitChangesRequests = couchDbVersion => {
     false;
 };
 
+const initCurrentSeq = () => db.medic.info().then(info => currentSeq = info.update_seq);
+
 const init = () => {
   if (!inited) {
     inited = true;
     initContinuousFeed();
-    return initServerChecks();
+    return Promise.all([
+      initCurrentSeq(),
+      initServerChecks()
+    ]);
   }
 
   return Promise.resolve();

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -22,6 +22,7 @@ if (UNIT_TEST_ENV) {
     'get',
     'getAttachment',
     'changes',
+    'info',
   ];
   const GLOBAL_FUNCTIONS_TO_STUB = [
     'get',

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -393,7 +393,7 @@ describe('Changes controller', () => {
       authorization.getAllowedDocIds.resolves(validatedIds);
       testReq.query = { since: 0 };
 
-      const expected = { results: [{ id: 1 }, { id: 2 }, { id: 3 }], last_seq: 22 };
+      const expected = { results: [{ id: 1, seq: 1 }, { id: 2, seq: 2 }, { id: 3, seq: 22 }], last_seq: 22 };
 
       controller.request(testReq, testRes);
       return nextTick()
@@ -639,9 +639,9 @@ describe('Changes controller', () => {
       testReq.query = { feed: 'longpoll' };
       authorization.getAllowedDocIds.resolves([1, 2, 3]);
       authorization.filterAllowedDocs.returns([
-        { change: { id: 1, changes: [] }, id: 1 },
-        { change: { id: 3, changes: [] }, id: 3 },
-        { change: { id: 2, changes: [] }, id: 2 }
+        { change: { id: 1, changes: [], seq: 4 }, id: 1 },
+        { change: { id: 3, changes: [], seq: 1 }, id: 3 },
+        { change: { id: 2, changes: [], seq: 2 }, id: 2 }
       ]);
 
       controller.request(testReq, testRes);
@@ -649,15 +649,15 @@ describe('Changes controller', () => {
         .then(() => {
           const emitter = controller._getContinuousFeed();
           const feed = controller._getNormalFeeds()[0];
-          emitter.emit('change', { id: 3, changes: [], doc: { _id: 3 }}, 0, 1);
+          emitter.emit('change', { id: 3, changes: [], doc: { _id: 3 }, seq: 1}, 0, 1);
           feed.pendingChanges.length.should.equal(1);
-          emitter.emit('change', { id: 2, changes: [], doc: { _id: 2 }}, 0, 2);
+          emitter.emit('change', { id: 2, changes: [], doc: { _id: 2 }, seq: 2}, 0, 2);
           feed.pendingChanges.length.should.equal(2);
-          emitter.emit('change', { id: 4, changes: [], doc: { _id: 4 }}, 0, 3);
+          emitter.emit('change', { id: 4, changes: [], doc: { _id: 4 }, seq: 3}, 0, 3);
           feed.pendingChanges.length.should.equal(3);
-          emitter.emit('change', { id: 1, changes: [], doc: { _id: 1 }}, 0, 4);
+          emitter.emit('change', { id: 1, changes: [], doc: { _id: 1 }, seq: 4}, 0, 4);
           feed.pendingChanges.length.should.equal(4);
-          feed.upstreamRequest.complete(null, { results: [{ id: 22 }], last_seq: 5 });
+          feed.upstreamRequest.complete(null, { results: [{ id: 22, seq: 5 }], last_seq: 5 });
         })
         .then(nextTick)
         .then(() => {
@@ -666,21 +666,48 @@ describe('Changes controller', () => {
           testRes.write.callCount.should.equal(1);
           testRes.write.args[0][0].should.equal(JSON.stringify({
             results: [
-              { id: 22 },
-              { id: 1, changes: [] },
-              { id: 3, changes: [] },
-              { id: 2, changes: [] }
+              { id: 22, seq: 5 },
+              { id: 1, changes: [], seq: 4 },
+              { id: 3, changes: [], seq: 1 },
+              { id: 2, changes: [], seq: 2 }
             ],
             last_seq: 5
           }));
           authorization.allowedDoc.callCount.should.equal(0);
           authorization.filterAllowedDocs.callCount.should.equal(1);
           authorization.filterAllowedDocs.args[0][1].should.deep.equal([
-            { change: { id: 3, changes: [] }, id: 3, viewResults: {} },
-            { change: { id: 2, changes: [] }, id: 2, viewResults: {} },
-            { change: { id: 4, changes: [] }, id: 4, viewResults: {} },
-            { change: { id: 1, changes: [] }, id: 1, viewResults: {} }
+            { change: { id: 3, changes: [], seq: 1 }, id: 3, viewResults: {} },
+            { change: { id: 2, changes: [], seq: 2 }, id: 2, viewResults: {} },
+            { change: { id: 4, changes: [], seq: 3 }, id: 4, viewResults: {} },
+            { change: { id: 1, changes: [], seq: 4 }, id: 1, viewResults: {} }
           ]);
+        });
+    });
+
+    it('should copy last change\'s seq as last_seq', () => {
+      const validatedIds = Array.from({length: 40}, () => Math.floor(Math.random() * 40));
+      authorization.getAllowedDocIds.resolves(validatedIds);
+      testReq.query = { since: 0 };
+
+      controller.request(testReq, testRes);
+      return nextTick()
+        .then(() => {
+          const feed = controller._getNormalFeeds()[0];
+          feed.upstreamRequest.complete(
+            null,
+            { results: [{ id: 1, seq: 1 }, { id: 2, seq: 2 }, { id: 3, seq: 3 }], last_seq: 22 }
+          );
+        })
+        .then(nextTick)
+        .then(() => {
+          testRes.write.callCount.should.equal(1);
+          testRes.write.args[0][0].should.equal(JSON.stringify({
+            results: [{ id: 1, seq: 1 }, { id: 2, seq: 2 }, { id: 3, seq: 3 }],
+            last_seq: 3
+          }));
+          testRes.end.callCount.should.equal(1);
+          controller._getNormalFeeds().length.should.equal(0);
+          controller._getLongpollFeeds().length.should.equal(0);
         });
     });
   });
@@ -1212,30 +1239,30 @@ describe('Changes controller', () => {
           const feed = controller._getLongpollFeeds()[0];
           const emitter = controller._getContinuousFeed();
           clock.tick(1000);
-          emitter.emit('change', { id: 3, changes: [], doc: { _id: 3 }}, 0, 1);
+          emitter.emit('change', { id: 3, changes: [], doc: { _id: 3 }, seq: 1}, 0, 1);
           clock.tick(1000);
-          emitter.emit('change', { id: 4, changes: [], doc: { _id: 4 }}, 0, 2);
+          emitter.emit('change', { id: 4, changes: [], doc: { _id: 4 }, seq: 2}, 0, 2);
           clock.tick(1000);
-          emitter.emit('change', { id: 1, changes: [], doc: { _id: 1 }}, 0, 3);
-          emitter.emit('change', { id: 22, changes: [], doc: { _id: 22 }}, 0, 3);
+          emitter.emit('change', { id: 1, changes: [], doc: { _id: 1 }, seq: 3}, 0, 3);
+          emitter.emit('change', { id: 22, changes: [], doc: { _id: 22 }, seq: 3}, 0, 3);
           controller._getLongpollFeeds().length.should.equal(0);
           feed.results.should.deep.equal([]);
           controller._getNormalFeeds()[0].should.equal(feed);
           authorization.getAllowedDocIds.callCount.should.equal(2);
-          emitter.emit('change', { id: 2, changes: [], doc: { _id: 2 }}, 0, 4);
-          emitter.emit('change', { id: 11, changes: [], doc: { _id: 11 }}, 0, 5);
+          emitter.emit('change', { id: 2, changes: [], doc: { _id: 2 }, seq: 4}, 0, 4);
+          emitter.emit('change', { id: 11, changes: [], doc: { _id: 11 }, seq: 5}, 0, 5);
           authorization.filterAllowedDocs.callCount.should.equal(1);
         })
         .then(nextTick)
         .then(() => {
           const feed = controller._getNormalFeeds()[0];
           feed.pendingChanges.should.deep.equal([
-            { change: { id: 22, changes: [] }, viewResults: {}, id: 22 },
-            { change: { id: 2, changes: [] }, viewResults: {}, id: 2 },
-            { change: { id: 11, changes: [] }, viewResults: {}, id: 11 },
+            { change: { id: 22, changes: [], seq: 3 }, viewResults: {}, id: 22 },
+            { change: { id: 2, changes: [], seq: 4 }, viewResults: {}, id: 2 },
+            { change: { id: 11, changes: [], seq: 5 }, viewResults: {}, id: 11 },
           ]);
           feed.upstreamRequest.complete(null, {
-            results: [{ id: 3, changes: [] }, { id: 1, changes: [] }, { id: 2, changes: [] }],
+            results: [{ id: 3, changes: [], seq: 1 }, { id: 1, changes: [], seq: 3 }, { id: 2, changes: [], seq: 4 }],
             last_seq: 5
           });
           (!!feed.ended).should.equal(false);
@@ -1249,15 +1276,15 @@ describe('Changes controller', () => {
           testRes.write.callCount.should.equal(1);
           testRes.end.callCount.should.equal(1);
           testRes.write.args[0][0].should.equal(JSON.stringify({
-            results: [{ id: 3, changes: [] }, { id: 1, changes: [] }, { id: 2, changes: [] }],
-            last_seq: 5
+            results: [{ id: 3, changes: [], seq: 1 }, { id: 1, changes: [], seq: 3 }, { id: 2, changes: [], seq: 4 }],
+            last_seq: 4
           }));
           authorization.filterAllowedDocs.callCount.should.equal(2);
           authorization.filterAllowedDocs.args[0][1].should.deep.equal([]);
           authorization.filterAllowedDocs.args[1][1].should.deep.equal([
-            { change: { id: 22, changes: [] }, viewResults: {}, id: 22 },
-            { change: { id: 2, changes: [] }, viewResults: {}, id: 2 },
-            { change: { id: 11, changes: [] }, viewResults: {}, id: 11 }
+            { change: { id: 22, changes: [], seq: 3 }, viewResults: {}, id: 22 },
+            { change: { id: 2, changes: [], seq: 4 }, viewResults: {}, id: 2 },
+            { change: { id: 11, changes: [], seq: 5 }, viewResults: {}, id: 11 }
           ]);
           authorization.allowedDoc.callCount.should.equal(3);
           authorization.allowedDoc.args[0][0].should.equal(3);
@@ -1332,7 +1359,7 @@ describe('Changes controller', () => {
             return_docs: true,
           });
           controller._getNormalFeeds().forEach(feed => {
-            feed.upstreamRequest.complete(null, { results: [], last_seq: 5 });
+            feed.upstreamRequest.complete(null, { results: [], last_seq: 0 });
           });
         })
         .then(nextTick)
@@ -1340,10 +1367,10 @@ describe('Changes controller', () => {
           const emitter = controller._getContinuousFeed();
           const feed = controller._getLongpollFeeds()[0];
           controller._getNormalFeeds().length.should.equal(0);
-          emitter.emit('change', { id: 1, changes: [{ rev: 1 }], doc: { _id: 1 }}, 0, 1);
-          emitter.emit('change', { id: 2, changes: [{ rev: 1 }], doc: { _id: 2 }}, 0, 2);
-          emitter.emit('change', { id: 3, changes: [{ rev: 1 }], doc: { _id: 3 }}, 0, 3);
-          emitter.emit('change', { id: 4, changes: [{ rev: 1 }], doc: { _id: 4 }}, 0, 4);
+          emitter.emit('change', { id: 1, changes: [{ rev: 1 }], doc: { _id: 1 }, seq: 1}, 0, 1);
+          emitter.emit('change', { id: 2, changes: [{ rev: 1 }], doc: { _id: 2 }, seq: 2}, 0, 2);
+          emitter.emit('change', { id: 3, changes: [{ rev: 1 }], doc: { _id: 3 }, seq: 3}, 0, 3);
+          emitter.emit('change', { id: 4, changes: [{ rev: 1 }], doc: { _id: 4 }, seq: 4}, 0, 4);
           feed.lastSeq.should.equal(4);
           clock.tick(300);
           testRes.write.callCount.should.equal(0);
@@ -1378,11 +1405,11 @@ describe('Changes controller', () => {
 
           feed.upstreamRequest.complete(null, {
             results: [
-              { id: 1, changes: [{ rev: 1 }] },
-              { id: 3, changes: [{ rev: 1 }] },
-              { id: 7, changes: [{ rev: 1 }] }
+              { id: 1, changes: [{ rev: 1 }], seq: 1 },
+              { id: 3, changes: [{ rev: 1 }], seq: 3 },
+              { id: 7, changes: [{ rev: 1 }], seq: 6 }
             ],
-            last_seq: 5
+            last_seq: 6
           });
         })
         .then(nextTick)
@@ -1391,8 +1418,12 @@ describe('Changes controller', () => {
           controller._getNormalFeeds().length.should.equal(0);
           testRes.write.callCount.should.equal(1);
           testRes.write.args[0][0].should.equal(JSON.stringify({
-            results: [{ id: 1, changes: [{ rev: 1 }]}, { id: 3, changes: [{ rev: 1 }]}, { id: 7, changes: [{ rev: 1 }]}],
-            last_seq: 5
+            results: [
+              { id: 1, changes: [{ rev: 1 }], seq: 1},
+              { id: 3, changes: [{ rev: 1 }], seq: 3},
+              { id: 7, changes: [{ rev: 1 }], seq: 6}
+            ],
+            last_seq: 6
           }));
         });
     });

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -430,17 +430,23 @@ describe('Changes controller', () => {
 
       return nextTick()
         .then(() => {
-          controller._getContinuousFeed().emit('change', { id: 7, changes: [], doc: { _id: 7 } }, 0, 4);
+          controller._getContinuousFeed().emit('change', { id: 7, changes: [], doc: { _id: 7 }, seq: 4 }, 0, 4);
         })
         .then(() => {
-          controller._getContinuousFeed().emit('change', { id: 8, changes: [], doc: { _id: 8 } }, 0, 5);
+          controller._getContinuousFeed().emit('change', { id: 8, changes: [], doc: { _id: 8 }, seq: 5 }, 0, 5);
         })
         .then(() => {
-          controller._getContinuousFeed().emit('change', { id: 9, changes: [], doc: { _id: 9 } }, 0, 6);
+          controller._getContinuousFeed().emit('change', { id: 9, changes: [], doc: { _id: 9 }, seq: 6 }, 0, 6);
         })
         .then(nextTick)
         .then(() => {
           const feed = controller._getNormalFeeds()[0];
+          feed.pendingChanges.length.should.equal(3);
+          feed.pendingChanges.should.deep.equal([
+            { change: { id: 7, changes: [] }, id: 7, viewResults: {} },
+            { change: { id: 8, changes: [] }, id: 8, viewResults: {} },
+            { change: { id: 9, changes: [] }, id: 9, viewResults: {} }
+          ]);
           feed.upstreamRequest.complete(null, expected);
         })
         .then(nextTick)

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -232,6 +232,7 @@ describe('Changes controller', () => {
         feed.req.userCtx.should.equal(userCtx);
         feed.lastSeq.should.equal('seq-1');
         feed.initSeq.should.equal(0);
+        feed.currentSeq.should.equal('seq-1');
         feed.pendingChanges.length.should.equal(0);
         feed.results.length.should.equal(0);
         feed.limit.should.equal(100);
@@ -704,6 +705,37 @@ describe('Changes controller', () => {
           testRes.write.args[0][0].should.equal(JSON.stringify({
             results: [{ id: 1, seq: 1 }, { id: 2, seq: 2 }, { id: 3, seq: 3 }],
             last_seq: 3
+          }));
+          testRes.end.callCount.should.equal(1);
+          controller._getNormalFeeds().length.should.equal(0);
+          controller._getLongpollFeeds().length.should.equal(0);
+        });
+    });
+
+    it('should copy currentSeq when results are empty', () => {
+      testReq.query = { since: 10 };
+      authorization.getAllowedDocIds.resolves([1, 2]);
+      controller.request(testReq, testRes);
+      const emitter = controller._getContinuousFeed();
+      emitter.emit('change', { id: 22, changes: [], doc: { _id: 22 }}, 0, 22);
+      return nextTick()
+        .then(() => {
+          emitter.emit('change', { id: 23, changes: [], doc: { _id: 23 }}, 0, 23);
+          emitter.emit('change', { id: 24, changes: [], doc: { _id: 24 }}, 0, 24);
+          emitter.emit('change', { id: 25, changes: [], doc: { _id: 25 }}, 0, 25);
+          emitter.emit('change', { id: 26, changes: [], doc: { _id: 26 }}, 0, 26);
+        })
+        .then(nextTick)
+        .then(() => {
+          const feed = controller._getNormalFeeds()[0];
+          feed.upstreamRequest.complete(null, { results: [], last_seq: 26 });
+        })
+        .then(nextTick)
+        .then(() => {
+          testRes.write.callCount.should.equal(1);
+          testRes.write.args[0][0].should.equal(JSON.stringify({
+            results: [],
+            last_seq: 22
           }));
           testRes.end.callCount.should.equal(1);
           controller._getNormalFeeds().length.should.equal(0);

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -475,7 +475,7 @@ describe('Changes controller', () => {
         });
     });
 
-    it('pushes allowed pending changes to the results, excluding their seq when batching', () => {
+    it('pushes allowed pending changes to the results, updating their seq when batching', () => {
       const validatedIds = Array.from({length: 101}, () => Math.floor(Math.random() * 101));
       serverChecks.getCouchDbVersion.resolves('2.3.0');
       authorization.getAllowedDocIds.resolves(validatedIds);
@@ -521,8 +521,8 @@ describe('Changes controller', () => {
               { id: 1, changes: [], seq: 1 },
               { id: 2, changes: [], seq: 2 },
               { id: 3, changes: [], seq: 3 },
-              { id: 8, changes: [] },
-              { id: 9, changes: [] }
+              { id: 8, changes: [], seq: 3 },
+              { id: 9, changes: [], seq: 3 }
             ],
             last_seq: 3
           }));

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -558,7 +558,7 @@ describe('changes handler', () => {
         ]))
         .then(([ p, changes ]) => {
           expect(ids.every(id => changes.find(change => change.id === id))).toBe(true);
-          expect(changes.some(change => !change.seq)).toBe(true);
+          expect(changes.some(change => !change.seq)).toBe(false);
         });
     });
 


### PR DESCRIPTION
# Description

PouchDB (as of 7.0.0) has four mechanisms for handling `last_seq` while replicating:

1. In the [Changes handler](https://github.com/pouchdb/pouchdb/blob/1da0eb6fbe33ea1aeb55e2b16f479a992ebcb5be/packages/node_modules/pouchdb-adapter-http/src/index.js#L1026) it uses `result.last_seq` to batch changes; this affected us in API prior to batching and Couch 2.3
2. In the Replication Handler ([here](https://github.com/pouchdb/pouchdb/blob/1da0eb6fbe33ea1aeb55e2b16f479a992ebcb5be/packages/node_modules/pouchdb-replication/src/replicate.js#L308) and [here](https://github.com/pouchdb/pouchdb/blob/1da0eb6fbe33ea1aeb55e2b16f479a992ebcb5be/packages/node_modules/pouchdb-replication/src/replicate.js#L133)) it uses the `seq` of the last change in a batch OR `result.last_seq` when writing local and remote checkpointer
3. In the Replication Handler ([here](https://github.com/pouchdb/pouchdb/blob/1da0eb6fbe33ea1aeb55e2b16f479a992ebcb5be/packages/node_modules/pouchdb-replication/src/replicate.js#L326)) it uses the `seq` of the last change in the whole response to use as a `since` param in the next _changes request
4. In the Replication Handler ([here](https://github.com/pouchdb/pouchdb/blob/1da0eb6fbe33ea1aeb55e2b16f479a992ebcb5be/packages/node_modules/pouchdb-replication/src/replicate.js#L344)) it uses the `result.last_seq` when writing the last checkpoint when replication is completed (no results returned by last _changes request). 

The issue this PR is fixing is when we receive changes, in between our view calls and the time that our upstream _changes request resolves, which should be seen by our user; these changes are pushed to our current response, because they would be skipped if our upstream result advances the checkpointer seq beyond theirs. 

There is no way of reliably comparing seq's or even knowing how many more changes we have left (the `pending` param is not affected by our _doc_ids filter), so I've decided to push these changes to any request, the downside being that they could end up being processed by PouchDB twice. 
In order to not have their possibly more recent `seq`s alter the replication algorithm in Pouch, before appending them to the result, I'm updating their seq to be equal to the `last_seq` received by the upstream filtered request. 

Also fixes a race condition where a new doc would be added before upstream changes feed responds, but the live changes feed receives it AFTER we send a response. Discovered because an e2e test failed a couple of times. 

medic/medic-webapp#5076

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
