### PR TITLE
Don’t set generic values

### DIFF
--- a/api/src/migrations/convert-translation-messages.js
+++ b/api/src/migrations/convert-translation-messages.js
@@ -31,19 +31,15 @@ module.exports = {
                 if (_.has(translationMessageValues, 'values')) {
                   return getAttachment(translationAttachmentKey)
                     .then((translationAttachmentValues) => {
-                      let genericTranslations = {};
                       let customTranslations = {}; 
                       return Promise.all(Object.keys(translationMessageValues.values).map((translationMessageKey) => {
-                        if (_.has(translationAttachmentValues, translationMessageKey)) {
-                          genericTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
-                        } else {
+                        if (!_.has(translationAttachmentValues, translationMessageKey)) {
                           customTranslations[translationMessageKey] = translationMessageValues.values[translationMessageKey];
                         }
                       }))
                       .then (() => {
                         delete translationMessageValues.values;
                         translationMessageValues.custom = customTranslations;
-                        translationMessageValues.generic = genericTranslations;
                         return db.medic.put(translationMessageValues);
                       });             
                     });

--- a/api/tests/integration/migrations/convert-translation-messages.js
+++ b/api/tests/integration/migrations/convert-translation-messages.js
@@ -38,7 +38,6 @@ describe('convert-translation-messages migration', function() {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          generic: { Contact: 'Contact', From: 'From' },
           custom: { hello: 'Hello', bye: 'Goodbye CUSTOMISED' },
         }
       ]);

--- a/api/tests/integration/migrations/convert-translation-messages.js
+++ b/api/tests/integration/migrations/convert-translation-messages.js
@@ -53,7 +53,7 @@ describe('convert-translation-messages migration', function() {
         _id: 'messages-en',
         code: 'en',
         type: 'translations',
-        generic: { Contact: 'Contact', From: 'From', hello: 'Hello' },
+        generic: { Contact: 'Contact', From: 'From', hello: 'Hi' },
         values: { hello: 'Bonjour', bye: 'Goodbye CUSTOMISED' }
       }
     ])
@@ -78,7 +78,7 @@ describe('convert-translation-messages migration', function() {
           _id: 'messages-en',
           code: 'en',
           type: 'translations',
-          generic: { Contact: 'Contact', From: 'From', hello: 'Hello' },
+          generic: { Contact: 'Contact', From: 'From', hello: 'Hi' },
           custom: { hello: 'Bonjour', bye: 'Goodbye CUSTOMISED' },
         }
       ]);

--- a/api/tests/integration/migrations/convert-translation-messages.js
+++ b/api/tests/integration/migrations/convert-translation-messages.js
@@ -45,6 +45,47 @@ describe('convert-translation-messages migration', function() {
 
   });
 
+  it('converts translation messages structure following an upgrade after merging', () => {
+
+    // given
+    return utils.initDb([
+      {
+        _id: 'messages-en',
+        code: 'en',
+        type: 'translations',
+        generic: { Contact: 'Contact', From: 'From', hello: 'Hello' },
+        values: { hello: 'Bonjour', bye: 'Goodbye CUSTOMISED' }
+      }
+    ])
+    .then(function() {
+      return utils.getDdoc(DDOC_ID);
+    })
+    .then(function(ddoc) {
+      const attachment = {
+        content_type: 'application/octet-stream',
+        content: 'Contact = Contact\nFrom = From',
+        key: 'translations/messages-en.properties'
+      };      
+      
+      return utils.insertAttachment(ddoc, attachment);  
+    })
+    .then(function() {
+      return utils.runMigration('convert-translation-messages');
+    })
+    .then(function() {
+      return utils.assertDb([
+        {
+          _id: 'messages-en',
+          code: 'en',
+          type: 'translations',
+          generic: { Contact: 'Contact', From: 'From', hello: 'Hello' },
+          custom: { hello: 'Bonjour', bye: 'Goodbye CUSTOMISED' },
+        }
+      ]);
+    });
+
+  });
+
   it('does nothing when translation messages have the new structure', () => {
 
     // given


### PR DESCRIPTION
# Description

It is already done by the translation merging process. In fact, it may cause invalid values to be mapped to generic.

medic/medic-webapp#5271

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
