### PR TITLE
Delete medic-test-user-admin-meta during reset-test-databases command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -447,7 +447,7 @@ module.exports = function(grunt) {
       },
       'reset-test-databases': {
         stderr: false,
-        cmd: ['medic-test', 'medic-test-audit']
+        cmd: ['medic-test', 'medic-test-audit', 'medic-test-user-admin-meta']
           .map(
             name => `curl -X DELETE ${couchConfig.withPath(name)}`
           )


### PR DESCRIPTION
# Description

Running e2e tests locally today was very slow and I had more transient failures than normal, particularly in the `_changes.spec.js` suite. Looking at the failures, my `medic-test-user-admin-meta` database was very large, I deleted it and tests reliability and speed improved. Sorry, I didn't take any measurements but the difference was quite obvious.

#5228

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
