### PR TITLE
Remove reference to 5986

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ curl http://localhost:5984 # should fail
 To be able to use Fauxton with authenticated users:
 
 ```shell
-curl -X PUT http://myAdminUser:myAdminPass@localhost:5986/_config/httpd/WWW-Authenticate \
+curl -X PUT 'http://myAdminUser:myAdminPass@localhost:5984/_node/$COUCH_NODE_NAME/_config/httpd/WWW-Authenticate' \
   -d '"Basic realm=\"administrator\""' -H "Content-Type: application/json"
 ```
 


### PR DESCRIPTION
We should never really reference it, and they're going to take it away soon.

Much better to go through the official node api instead.