### PR TITLE
Create user's meta dbs correctly

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -65,7 +65,7 @@ if (UNIT_TEST_ENV) {
     const db = new PouchDB(getDbUrl(name), { skip_setup: true });
     return db.info()
       .then(result => {
-        // In at least PouchDB 7.0.0, info() on a non-existant doc doesn't throw,
+        // In at least PouchDB 7.0.0, info() on a non-existant db doesn't throw,
         // instead it returns the error structure
         return  !result.error;
       })

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -64,7 +64,11 @@ if (UNIT_TEST_ENV) {
   module.exports.exists = name => {
     const db = new PouchDB(getDbUrl(name), { skip_setup: true });
     return db.info()
-      .then(() => true)
+      .then(result => {
+        // In at least PouchDB 7.0.0, info() on a non-existant doc doesn't throw,
+        // instead it returns the error structure
+        return  !result.error;
+      })
       .catch(() => false);
   };
 }

--- a/api/src/services/user-db.js
+++ b/api/src/services/user-db.js
@@ -63,9 +63,11 @@ module.exports = {
     const dbName = module.exports.getDbName(username);
     return db.exists(dbName).then(found => {
       if (!found) {
-        return db.get(dbName)
-          .then(database => database.put(ddoc))
-          .then(() => setSecurity(dbName, username));
+        const database = db.get(dbName);
+        return database.put(ddoc)
+          .then(result => {
+            return setSecurity(dbName, username);
+          });
       }
     });
   }

--- a/api/src/services/user-db.js
+++ b/api/src/services/user-db.js
@@ -65,7 +65,7 @@ module.exports = {
       if (!found) {
         const database = db.get(dbName);
         return database.put(ddoc)
-          .then(result => {
+          .then(() => {
             return setSecurity(dbName, username);
           });
       }

--- a/api/tests/integration/migrations/utils.js
+++ b/api/tests/integration/migrations/utils.js
@@ -199,7 +199,7 @@ const _resetDb = () => {
       logger.error('Could not create "medic-test" directly after deleting, pausing and trying again');
       return new Promise(function(resolve, reject) {
         setTimeout(function() {
-          db.get('medic-test')
+          db.exists('medic-test')
             .then(() => {
               logger.info(`After a struggle, at ${new Date()}, re-created "medic-test"`);
               resolve();

--- a/api/tests/mocha/services/user-db.spec.js
+++ b/api/tests/mocha/services/user-db.spec.js
@@ -42,7 +42,7 @@ describe('User DB service', () => {
 
     it('creates the db if it does not exist', () => {
       const userDb = { put: function() {} };
-      const create = sinon.stub(db, 'exists').resolves({error: 'not_found'});
+      const create = sinon.stub(db, 'exists').resolves(false);
       const get = sinon.stub(db, 'get').returns(userDb);
       const dbPut = sinon.stub(userDb, 'put').resolves();
       const requestPut = sinon.stub(request, 'put').resolves();

--- a/api/tests/mocha/services/user-db.spec.js
+++ b/api/tests/mocha/services/user-db.spec.js
@@ -42,8 +42,8 @@ describe('User DB service', () => {
 
     it('creates the db if it does not exist', () => {
       const userDb = { put: function() {} };
-      const create = sinon.stub(db, 'exists').resolves(false);
-      const get = sinon.stub(db, 'get').resolves(userDb);
+      const create = sinon.stub(db, 'exists').resolves({error: 'not_found'});
+      const get = sinon.stub(db, 'get').returns(userDb);
       const dbPut = sinon.stub(userDb, 'put').resolves();
       const requestPut = sinon.stub(request, 'put').resolves();
       environment.protocol = 'http:';

--- a/webapp/src/js/services/db.js
+++ b/webapp/src/js/services/db.js
@@ -50,6 +50,8 @@ angular.module('inboxServices').factory('DB',
     const getParams = (remote, meta) => {
       const clone = Object.assign({}, remote ? POUCHDB_OPTIONS.remote : POUCHDB_OPTIONS.local);
       if (remote && meta) {
+        // Don't create user DBs remotely, we do this ourselves in /api/services/user-db:create,
+        // which is called in routing when a user tries to access the DB
         clone.skip_setup = false;
       }
       return clone;


### PR DESCRIPTION
I think this was broken in c9f192ce1eb6e21505dd9a1c69ed648a9b06fa80, but I'm not sure.

Two parts didn't work:
 - db.info() doesn't throw when the DB doesn't exist, it just returns the error
 - We were treating PouchDB instantiation as a promise