### PR TITLE
Fixing purge's hash function

### DIFF
--- a/webapp/src/js/bootstrapper/purger.js
+++ b/webapp/src/js/bootstrapper/purger.js
@@ -16,8 +16,8 @@ const hash = str => {
         return hash;
     }
 
-    for (let i = 0; i < this.length; i++) {
-        const char = this.charCodeAt(i);
+    for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
         /* eslint-disable no-bitwise */
         hash = ((hash << 5) - hash) + char;
         hash = hash & hash; // Convert to 32bit integer


### PR DESCRIPTION
The hash function was incorrectly generating every hash as '0'.

As 0 is falsy in JS, that constituted no hash at all, and so it would always think 
something had changed.

medic/medic#5048