### PR TITLE
[WIP] 5267 - Re-enable e2e spec targeting restricted users + service workers

### DIFF
--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -4,7 +4,7 @@ const auth = require('../../auth')(),
       utils = require('../../utils'),
       loginPage = require('../../page-objects/login/login.po.js');
 
-xdescribe('Purging on login', () => {
+describe('Purging on login', () => {
 
   const restrictedUserName = 'e2e_restricted',
         restrictedPass = 'e2e_restricted',
@@ -175,7 +175,7 @@ xdescribe('Purging on login', () => {
   beforeEach(utils.beforeEach);
   afterEach(utils.afterEach);
 
-  xit('Logging in as a restricted user with configured purge rules should perform a purge', () => {
+  it('Logging in as a restricted user with configured purge rules should perform a purge', () => {
     utils.resetBrowser();
     commonElements.goToLoginPage();
     loginPage.login(restrictedUserName, restrictedPass);


### PR DESCRIPTION
# Description

Note the base branch here is `4713-appcache` from PR #5219 which is currently in review. I need to run this test in travis, so creating this new PR so work here doesn't get in the way of the core service worker review.

#5267

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
