### PR TITLE
Api service fails to start via npm start

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -430,7 +430,7 @@ module.exports = function(grunt) {
       },
       'api-dev': {
         cmd:
-          'TZ=UTC ./node_modules/.bin/nodemon --watch api api/server.js -- --allow-cors',
+          'TZ=UTC ./node_modules/.bin/nodemon --ignore "api/src/extracted-resources/**" --watch api api/server.js -- --allow-cors',
       },
       'sentinel-dev': {
         cmd:

--- a/api/src/resource-extraction.js
+++ b/api/src/resource-extraction.js
@@ -11,7 +11,7 @@ const
   environment = require('./environment'),
   logger = require('./logger'),
   APP_PREFIX_TOKEN = 'APP_PREFIX',
-  STATIC_RESOURCE_DESTINATION = path.resolve(`./src/extracted-resources/`),
+  STATIC_RESOURCE_DESTINATION = path.join(__dirname, `extracted-resources/`),
   isAttachmentCacheable = name => name === 'manifest.json' || !!name.match(/(?:audio|css|fonts|templates|img|js|xslt)\/.*/);
 
 // Map of attachmentName -> attachmentDigest used to avoid extraction of unchanged documents


### PR DESCRIPTION
# Description

API service fails to start when run via `npm start`.

```Error: ENOENT: no such file or directory, mkdir '/Users/wtekeu/projects/codes/medic-webapp/src/extracted-resources'```

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
