### PR TITLE
5267 - Re-enable purging spec together with service worker

### DIFF
--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -4,7 +4,7 @@ const auth = require('../../auth')(),
       utils = require('../../utils'),
       loginPage = require('../../page-objects/login/login.po.js');
 
-xdescribe('Purging on login', () => {
+describe('Purging on login', () => {
 
   const restrictedUserName = 'e2e_restricted',
         restrictedPass = 'e2e_restricted',
@@ -175,7 +175,7 @@ xdescribe('Purging on login', () => {
   beforeEach(utils.beforeEach);
   afterEach(utils.afterEach);
 
-  xit('Logging in as a restricted user with configured purge rules should perform a purge', () => {
+  it('Logging in as a restricted user with configured purge rules should perform a purge', () => {
     utils.resetBrowser();
     commonElements.goToLoginPage();
     loginPage.login(restrictedUserName, restrictedPass);

--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -164,7 +164,7 @@
             });
         }
       })
-      .then(() => purger(localDb, isInitialReplicationNeeded)
+      .then(() => purger(localDb, userCtx, isInitialReplicationNeeded)
         .on('start', () => setUiStatus('PURGE_INIT'))
         .on('progress', function(progress) {
           setUiStatus('PURGE_INFO', {


### PR DESCRIPTION
# Description

This test originally failed because of issues with Chrome 71. Re-enabling it now that Chrome 72 is stable (used in travis), it appears it's now broken because I removed the userCtx parameter during a rebase by mistake.

#5267

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
