### PR TITLE
Fix patient_id_field registration add_patient.

### DIFF
--- a/sentinel/src/transitions/utils.js
+++ b/sentinel/src/transitions/utils.js
@@ -45,7 +45,7 @@ module.exports = {
     db.medic.query('medic-client/contacts_by_reference', {
       key: [ 'shortcode', id ]
     }, (err, results) => {
-      callback(err, !!(results && results.rows && results.rows.length));
+      callback(err, !(results && results.rows && results.rows.length));
     });
   },
   addUniqueId: (doc, callback) => {


### PR DESCRIPTION
# Description

Updates `transitionUtils.isIdUnique` to return `true` when no rows are found, `false` otherwise.

medic/medic#5345

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
