### PR TITLE
Prevents schedule from starting mid-group

### DIFF
--- a/sentinel/src/lib/schedules.js
+++ b/sentinel/src/lib/schedules.js
@@ -72,7 +72,8 @@ module.exports = {
             start,
             now = moment(date.getDate()),
             muted = patient && (patient.muted || mutingUtils.isMutedInLineage(patient)),
-            allowedState = muted ? 'muted' : 'scheduled';
+            allowedState = muted ? 'muted' : 'scheduled',
+            skipGroups = [];
 
         // if we  can't find the schedule in config, we're done also if forms
         // mismatch or already run.
@@ -103,6 +104,10 @@ module.exports = {
                 send_time = module.exports.getSendTime(msg.send_time),
                 message = messages.getMessage(msg, locale);
 
+            if (skipGroups.includes(msg.group)) {
+                return;
+            }
+
             if (offset) {
                 due = start.clone().add(offset);
                 if (send_time.length >= 2) {
@@ -122,6 +127,9 @@ module.exports = {
                 }
                 // don't schedule messages in the past or empty messages
                 if (due < now || !message) {
+                    if (schedule.start_mid_group === false) {
+                        skipGroups.push(msg.group);
+                    }
                     return;
                 }
 

--- a/sentinel/src/lib/schedules.js
+++ b/sentinel/src/lib/schedules.js
@@ -127,7 +127,7 @@ module.exports = {
                 }
                 // don't schedule messages in the past or empty messages
                 if (due < now || !message) {
-                    if (schedule.start_mid_group === false) {
+                    if (!schedule.start_mid_group) {
                         skipGroups.push(msg.group);
                     }
                     return;

--- a/sentinel/tests/unit/schedules.js
+++ b/sentinel/tests/unit/schedules.js
@@ -410,7 +410,7 @@ describe('schedules', () => {
     assert.equal(config.getAll.callCount, 1);
   });
 
-  it('skips a group when starting mid-group and flag start_mid_group is false', () => {
+  it('skips a group when starting mid-group by default', () => {
       var added;
 
       var doc = {
@@ -445,4 +445,40 @@ describe('schedules', () => {
       assert.equal(added, false);
       assert(!doc.scheduled_tasks);
   });  
+
+  it('does not skip a group when starting mid-group and flag start_mid_group is true', () => {
+      var added;
+
+      var doc = {
+          form: 'x',
+          lmp_date: moment().valueOf()
+      };
+
+      added = schedules.assignSchedule(doc, {
+          name: 'duckland',
+          start_from: 'lmp_date',
+          start_mid_group: true,
+          messages: [
+              {
+                  group: 1,
+                  offset: '-12 weeks',
+                  message: [{
+                      content: 'Past message.',
+                      locale: 'en'
+                  }]
+              },
+              {
+                  group: 1,
+                  offset: '13 weeks',
+                  message: [{
+                      content: 'Future message.',
+                      locale: 'en'
+                  }]
+              }
+          ]
+      });
+
+      assert.equal(added, true);
+      assert.equal(doc.scheduled_tasks.length, 1);
+  }); 
 });

--- a/sentinel/tests/unit/schedules.js
+++ b/sentinel/tests/unit/schedules.js
@@ -409,4 +409,40 @@ describe('schedules', () => {
     );
     assert.equal(config.getAll.callCount, 1);
   });
+
+  it('skips a group when starting mid-group and flag start_mid_group is false', () => {
+      var added;
+
+      var doc = {
+          form: 'x',
+          lmp_date: moment().valueOf()
+      };
+
+      added = schedules.assignSchedule(doc, {
+          name: 'duckland',
+          start_from: 'lmp_date',
+          start_mid_group: false,
+          messages: [
+              {
+                  group: 1,
+                  offset: '-12 weeks',
+                  message: [{
+                      content: 'Past message.',
+                      locale: 'en'
+                  }]
+              },
+              {
+                  group: 1,
+                  offset: '13 weeks',
+                  message: [{
+                      content: 'Future message.',
+                      locale: 'en'
+                  }]
+              }
+          ]
+      });
+
+      assert.equal(added, false);
+      assert(!doc.scheduled_tasks);
+  });  
 });


### PR DESCRIPTION
# Description

This requires a config change. You need to add `"start_mid_group": false` to the definition of the schedule. For instace:
```
      {
        "name": "ANC Reminders LMP",
        "translation_key": "schedule.anc_lmp",
        "summary": "",
        "description": "",
        "start_from": "lmp_date",
        "start_mid_group": false,
        "messages": [
```

medic/medic#3093

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
