### PR TITLE
Fixes update_scheduled_reports

### DIFF
--- a/ddocs/medic/views/reports_by_form_year_month_clinic_id_reported_date/map.js
+++ b/ddocs/medic/views/reports_by_form_year_month_clinic_id_reported_date/map.js
@@ -2,7 +2,6 @@ function (doc) {
   if (doc.type === 'data_record' &&
       doc.contact &&
       doc.contact.parent &&
-      doc.year &&
       doc.fields &&
       doc.fields.year &&
       (doc.fields.month || doc.fields.month_num) &&

--- a/sentinel/src/transitions/update_scheduled_reports.js
+++ b/sentinel/src/transitions/update_scheduled_reports.js
@@ -1,10 +1,8 @@
-var utils = require('../lib/utils'),
+const utils = require('../lib/utils'),
   db = require('../db'),
-  logger = require('../lib/logger');
-
-const transitionUtils = require('./utils');
-
-const NAME = 'update_scheduled_reports';
+  logger = require('../lib/logger'),
+  transitionUtils = require('./utils'),
+  NAME = 'update_scheduled_reports';
 
 module.exports = {
   filter: (doc, info = {}) => {
@@ -19,83 +17,53 @@ module.exports = {
   },
   /**
    * If a record has a month/week/week_number, year and clinic then look for
-   * duplicates and update those instead.
-   *
-   * POST creates doc
-   * GET  /scheduled_reports/:form/:year/:week|month/:clinic_id (look for dups)
-   *
+   * duplicates and delete them.
    */
   onMatch: change => {
-    return new Promise((resolve, reject) => {
-      var self = module.exports;
-      self._getDuplicates(change.doc, function(err, rows) {
-        if (err) {
-          return reject(err);
+    return module.exports._getDuplicates(change.doc).then(rows => {
+      if (!rows || !rows.length) {
+        return;
+      }
+
+      if (rows.length === 1) {
+        return true;
+      }
+
+      const duplicates = [];
+      rows.forEach(row => {
+        if (row.doc._id === change.doc._id) {
+          return;
         }
 
-        // the doc was not correctly attached to a clinic
-        if (!rows || !rows.length) {
-          return resolve();
-        }
-
-        // only one record in duplicates, mark transition complete
-        if (rows && rows.length === 1) {
-          return resolve(true);
-        }
-
-        // remove duplicates and replace with latest doc
-        var found_target,
-          docs = [];
-
-        rows.forEach(row => {
-          var doc = row.doc;
-          if (doc._id === change.doc._id) {
-            doc._deleted = true;
-          } else if (!found_target) {
-            var id = doc._id,
-              rev = doc._rev;
-            found_target = true;
-            // overwrite data except _rev and _id fields
-            doc = change.doc;
-            doc._id = id;
-            doc._rev = rev;
-          } else {
-            doc._deleted = true;
-          }
-          docs.push(doc);
-        });
-
-        db.medic.bulkDocs(
-          docs,
-          function(err) {
-            // cancels transition and marks as incomplete
-            if (err) {
-              logger.error('error doing bulk save: %o', err);
-              return resolve();
-            }
-            return resolve(true);
-          }
-        );
+        row.doc._deleted = true;
+        duplicates.push(row.doc);
       });
+
+      return db.medic
+        .bulkDocs(duplicates)
+        .then(() => true)
+        .catch(err => {
+          logger.error('error doing bulk save: %o', err);
+        });
     });
   },
   //
   // look for duplicate from same year, month/week and reporting unit
   // also includes changed doc
   //
-  _getDuplicates: function(doc, callback) {
-    var q = { include_docs: true },
-      view,
-      clinicId = utils.getClinicID(doc);
+  _getDuplicates: doc => {
+    const options = { include_docs: true },
+          clinicId = utils.getClinicID(doc);
+    let view;
 
     if (doc.fields.week || doc.fields.week_number) {
-      q.startkey = [
+      options.startkey = [
         doc.form,
         doc.fields.year,
         doc.fields.week || doc.fields.week_number,
         clinicId,
       ];
-      q.endkey = [
+      options.endkey = [
         doc.form,
         doc.fields.year,
         doc.fields.week || doc.fields.week_number,
@@ -104,13 +72,13 @@ module.exports = {
       ];
       view = 'reports_by_form_year_week_clinic_id_reported_date';
     } else if (doc.fields.month || doc.fields.month_num) {
-      q.startkey = [
+      options.startkey = [
         doc.form,
         doc.fields.year,
         doc.fields.month || doc.fields.month_num,
         clinicId,
       ];
-      q.endkey = [
+      options.endkey = [
         doc.form,
         doc.fields.year,
         doc.fields.month || doc.fields.month_num,
@@ -121,12 +89,10 @@ module.exports = {
     }
 
     if (!view || !clinicId) {
-      return callback();
+      return Promise.resolve();
     }
 
-    db.medic.query(`medic/${view}`, q, function(err, data) {
-      callback(err, data && data.rows);
-    });
+    return db.medic.query(`medic/${view}`, options).then(data => data && data.rows);
   },
   _isFormScheduled: function(doc) {
     return (
@@ -137,5 +103,5 @@ module.exports = {
         doc.fields.week_number) &&
       doc.fields.year
     );
-  },
+  }
 };

--- a/sentinel/src/transitions/update_scheduled_reports.js
+++ b/sentinel/src/transitions/update_scheduled_reports.js
@@ -33,6 +33,7 @@ module.exports = {
           return reject(err);
         }
 
+        // the doc was not correctly attached to a clinic
         if (!rows || !rows.length) {
           return resolve();
         }
@@ -85,24 +86,20 @@ module.exports = {
   _getDuplicates: function(doc, callback) {
     var q = { include_docs: true },
       view,
-      clinic_id = utils.getClinicID(doc);
-
-    if (!clinic_id) {
-      return callback();
-    }
+      clinicId = utils.getClinicID(doc);
 
     if (doc.fields.week || doc.fields.week_number) {
       q.startkey = [
         doc.form,
         doc.fields.year,
         doc.fields.week || doc.fields.week_number,
-        clinic_id,
+        clinicId,
       ];
       q.endkey = [
         doc.form,
         doc.fields.year,
         doc.fields.week || doc.fields.week_number,
-        clinic_id,
+        clinicId,
         {},
       ];
       view = 'reports_by_form_year_week_clinic_id_reported_date';
@@ -111,17 +108,19 @@ module.exports = {
         doc.form,
         doc.fields.year,
         doc.fields.month || doc.fields.month_num,
-        clinic_id,
+        clinicId,
       ];
       q.endkey = [
         doc.form,
         doc.fields.year,
         doc.fields.month || doc.fields.month_num,
-        clinic_id,
+        clinicId,
         {},
       ];
       view = 'reports_by_form_year_month_clinic_id_reported_date';
-    } else {
+    }
+
+    if (!view || !clinicId) {
       return callback();
     }
 

--- a/sentinel/tests/unit/transitions/update_scheduled_reports.js
+++ b/sentinel/tests/unit/transitions/update_scheduled_reports.js
@@ -150,7 +150,7 @@ describe('update_scheduled_reports', () => {
   });
 
   describe('getDuplicates', () => {
-    it('should not query when clinic not found', done => {
+    it('should not query when clinic not found', () => {
       const doc = {
         type: 'data_record',
         form: 'form',
@@ -162,15 +162,13 @@ describe('update_scheduled_reports', () => {
       sinon.stub(utils, 'getClinicID').returns(false);
       sinon.stub(db.medic, 'query');
 
-      transition._getDuplicates(doc, (err, result) => {
+      return transition._getDuplicates(doc).then(result => {
         assert.equal(result, undefined);
-        assert.equal(err, undefined);
         assert.equal(db.medic.query.callCount, 0);
-        done();
       });
     });
 
-    it('use week view when doc has week property', done => {
+    it('use week view when doc has week property', () => {
       const doc = {
         type: 'data_record',
         form: 'form',
@@ -179,9 +177,9 @@ describe('update_scheduled_reports', () => {
           year: 2018
         }
       };
-      sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [{ doc }] });
+      sinon.stub(db.medic, 'query').resolves({ rows: [{ doc }] });
       sinon.stub(utils, 'getClinicID').returns('clinic');
-      transition._getDuplicates(doc, (err, result) => {
+      return transition._getDuplicates(doc).then(result => {
         assert.equal(
           db.medic.query.args[0][0],
           'medic/reports_by_form_year_week_clinic_id_reported_date'
@@ -192,12 +190,10 @@ describe('update_scheduled_reports', () => {
           endkey: ['form', 2018, 9, 'clinic', {}],
         });
         assert.deepEqual(result, [{ doc }]);
-        assert.equal(err, undefined);
-        done();
       });
     });
 
-    it('use month view when doc has month property', done => {
+    it('use month view when doc has month property', () => {
       const doc = {
         type: 'data_record',
         form: 'form',
@@ -206,9 +202,9 @@ describe('update_scheduled_reports', () => {
           year: 2018
         }
       };
-      sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [{ doc }] });
+      sinon.stub(db.medic, 'query').resolves({ rows: [{ doc }] });
       sinon.stub(utils, 'getClinicID').returns('clinic');
-      transition._getDuplicates(doc, (err, result) => {
+      return transition._getDuplicates(doc).then(result => {
         assert.equal(
           db.medic.query.args[0][0],
           'medic/reports_by_form_year_month_clinic_id_reported_date'
@@ -219,8 +215,6 @@ describe('update_scheduled_reports', () => {
           endkey: ['form', 2018, 9, 'clinic', {}],
         });
         assert.deepEqual(result, [{ doc }]);
-        assert.equal(err, undefined);
-        done();
       });
     });
   });
@@ -262,7 +256,7 @@ describe('update_scheduled_reports', () => {
       };
       const view = sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, { rows: [{ doc: change.doc }] });
+        .resolves({ rows: [{ doc: change.doc }] });
       sinon.stub(utils, 'getClinicID').returns('clinic');
 
       return transition.onMatch(change).then(changed => {
@@ -272,8 +266,8 @@ describe('update_scheduled_reports', () => {
       });
     });
 
-    it('remove duplicates and replace with latest doc', () => {
-      sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    it('remove duplicates', () => {
+      sinon.stub(db.medic, 'query').resolves({
         // ascending records
         rows: [
           {
@@ -293,6 +287,20 @@ describe('update_scheduled_reports', () => {
           {
             key: [2013, 4],
             doc: {
+              _id: 'qwe',
+              _rev: '1-qqq',
+              form: 'z',
+              fields: {
+                month: 4,
+                year: 2013,
+                pills: 16,
+              },
+              reported_date: 150,
+            },
+          },
+          {
+            key: [2013, 4],
+            doc: {
               _id: 'xyz',
               _rev: '1-kkkk',
               form: 'z',
@@ -303,10 +311,10 @@ describe('update_scheduled_reports', () => {
               },
               reported_date: 200,
             },
-          },
+          }
         ],
       });
-      const bulkSave = sinon.stub(db.medic, 'bulkDocs').callsArg(1);
+      const bulkSave = sinon.stub(db.medic, 'bulkDocs').resolves();
       const change = {
         doc: {
           _id: 'xyz',
@@ -325,16 +333,101 @@ describe('update_scheduled_reports', () => {
         assert.equal(changed, true);
         assert.equal(bulkSave.callCount, 1);
         assert.equal(bulkSave.args[0][0].length, 2);
-        // new doc inherits id/rev from previous record and is deleted
-        bulkSave.args[0][0].forEach(doc => {
-          if (doc._id === 'abc') {
-            assert.equal(doc._rev, '1-dddd');
-            assert.equal(doc.fields.pills, 22);
-          }
-          if (doc._id === 'xyz') {
-            assert.equal(doc._deleted, true);
-          }
+        assert.deepEqual(bulkSave.args[0][0][0], {
+          _id: 'abc',
+          _rev: '1-dddd',
+          form: 'z',
+          fields: {
+            month: 4,
+            year: 2013,
+            pills: 12,
+          },
+          reported_date: 100,
+          _deleted: true
         });
+
+        assert.deepEqual(bulkSave.args[0][0][1], {
+          _id: 'qwe',
+          _rev: '1-qqq',
+          form: 'z',
+          fields: {
+            month: 4,
+            year: 2013,
+            pills: 16,
+          },
+          reported_date: 150,
+          _deleted: true
+        });
+      });
+    });
+
+    it('should return undefined if bulkDocs fails', () => {
+      sinon.stub(db.medic, 'query').resolves({
+        // ascending records
+        rows: [
+          {
+            key: [2013, 4],
+            doc: {
+              _id: 'abc',
+              _rev: '1-dddd',
+              form: 'z',
+              fields: {
+                month: 4,
+                year: 2013,
+                pills: 12,
+              },
+              reported_date: 100,
+            },
+          },
+          {
+            key: [2013, 4],
+            doc: {
+              _id: 'qwe',
+              _rev: '1-qqq',
+              form: 'z',
+              fields: {
+                month: 4,
+                year: 2013,
+                pills: 16,
+              },
+              reported_date: 150,
+            },
+          },
+          {
+            key: [2013, 4],
+            doc: {
+              _id: 'xyz',
+              _rev: '1-kkkk',
+              form: 'z',
+              fields: {
+                month: 4,
+                year: 2013,
+                pills: 22,
+              },
+              reported_date: 200,
+            },
+          }
+        ],
+      });
+      sinon.stub(db.medic, 'bulkDocs').rejects({ some: 'err' });
+      const change = {
+        doc: {
+          _id: 'xyz',
+          _rev: '1-kkkk',
+          form: 'z',
+          fields: {
+            month: 4,
+            year: 2013,
+            pills: 22,
+          },
+          reported_date: 200,
+        },
+      };
+      sinon.stub(utils, 'getClinicID').returns('clinic');
+      return transition.onMatch(change).then(result => {
+        assert.equal(result, undefined);
+        assert.equal(db.medic.bulkDocs.callCount, 1);
+        assert.equal(db.medic.bulkDocs.args[0][0].length, 2);
       });
     });
   });


### PR DESCRIPTION
# Description

- Changes `filter` function to check if the transition has already run
- Fixes `reports_by_form_year_month_clinic_id_reported_date` to not test for legacy `doc.year`
- Switches logic from deleting current doc and updating old duplicate to deleting old duplicate
- Refactors to use promises instead of callbacks

medic/medic#5347

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
