### PR TITLE
Fixes death_reporting filter.

### DIFF
--- a/sentinel/src/transitions/death_reporting.js
+++ b/sentinel/src/transitions/death_reporting.js
@@ -60,9 +60,9 @@ module.exports = {
     }
   },
   filter: (doc, info = {}) => {
-    return (
+    return Boolean(
       doc &&
-      doc.from &&
+      doc.form &&
       doc.type === 'data_record' &&
       (isConfirmForm(doc.form) || isUndoForm(doc.form)) &&
       doc.fields &&

--- a/sentinel/tests/unit/transitions/death_reporting.js
+++ b/sentinel/tests/unit/transitions/death_reporting.js
@@ -196,4 +196,31 @@ describe('death_reporting', () => {
       });
     });
   });
+
+  describe('filter', () => {
+    it('empty doc returns false', () => {
+      transition.filter({}).should.equal(false);
+    });
+
+    it('no type returns false', () => {
+      sinon.stub(config, 'get').returns({ mark_deceased_forms: ['x', 'y'] });
+      transition.filter({ form: 'x' }).should.equal(false);
+      transition.filter({ from: 'x' }).should.equal(false);
+    });
+
+    it('no patient_id returns false', () => {
+      sinon.stub(config, 'get').returns({ mark_deceased_forms: ['x', 'y'] });
+      transition.filter({ form: 'x', type: 'data_record' }).should.equal(false);
+    });
+
+    it('returns true', () => {
+      sinon.stub(config, 'get').returns({
+        mark_deceased_forms: ['x', 'y'],
+        undo_deceased_forms: ['z', 't']
+      });
+
+      transition.filter({ type: 'data_record', form: 'z', fields: { patient_id: '12' } }).should.equal(true);
+      transition.filter({ type: 'data_record', form: 't', fields: { patient_id: '12' } }).should.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
# Description

Allows submiters without a phone number to successfully register a death.

medic/medic#5359
# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
