### PR TITLE
Fixes translation and API error reporting.

### DIFF
--- a/admin/src/js/controllers/edit-user.js
+++ b/admin/src/js/controllers/edit-user.js
@@ -331,9 +331,9 @@ angular
                 })
                 .catch(function(err) {
                   if (err && err.data && err.data.error && err.data.error.translationKey) {
-                    Translate(err.data.error.translationKey, err.data.error.translationParams).then(function(value) {
+                    $translate(err.data.error.translationKey, err.data.error.translationParams).then(function(value) {
                       $scope.setError(err, value);
-                    });           
+                    });
                   } else {
                     $scope.setError(err, 'Error updating user');
                   }

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -19,7 +19,7 @@ var writeJSON = function(res, code, message, details) {
 };
 
 var respond = function(req, res, code, message, details) {
-  if (wantsJSON(req)) {
+  if (wantsJSON(req) || typeof message === 'object') {
     return writeJSON(res, code, message, details);
   }
   if (!res.headersSent) {


### PR DESCRIPTION
# Description

Changes to use angular $translate instead of Translate service.
Fixes API error where `message` property is an object, forcing JSON instead of plain text.

medic/medic#4209

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
