### PR TITLE
4750 Moves enketoStatus to redux store

### DIFF
--- a/webapp/src/js/actions/index.js
+++ b/webapp/src/js/actions/index.js
@@ -1,6 +1,5 @@
 angular.module('inboxServices').factory('Actions',
   function() {
-    'ngInject';
     'use strict';
 
     return function(dispatch) {
@@ -14,6 +13,33 @@ angular.module('inboxServices').factory('Actions',
         };
       }
 
+      function createSetEnketoErrorAction(error) {
+        return {
+          type: 'SET_ENKETO_ERROR',
+          payload: {
+            error: error
+          }
+        };
+      }
+
+      function createSetEnketoEditedStatusAction(edited) {
+        return {
+          type: 'SET_ENKETO_EDITED_STATUS',
+          payload: {
+            edited: edited
+          }
+        };
+      }
+
+      function createSetEnketoSavingStatusAction(saving) {
+        return {
+          type: 'SET_ENKETO_SAVING_STATUS',
+          payload: {
+            saving: saving
+          }
+        };
+      }
+
       return {
         clearCancelCallback: function() {
           dispatch(createSetCancelCallbackAction(null));
@@ -21,6 +47,18 @@ angular.module('inboxServices').factory('Actions',
 
         setCancelCallback: function(cancelCallback) {
           dispatch(createSetCancelCallbackAction(cancelCallback));
+        },
+
+        setEnketoError: function(error) {
+          dispatch(createSetEnketoErrorAction(error));
+        },
+
+        setEnketoEditedStatus: function(edited) {
+          dispatch(createSetEnketoEditedStatusAction(edited));
+        },
+
+        setEnketoSavingStatus: function(saving) {
+          dispatch(createSetEnketoSavingStatusAction(saving));
         }
       };
     };

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -20,6 +20,7 @@ var feedback = require('../modules/feedback'),
     $transitions,
     $translate,
     $window,
+    Actions,
     APP_CONFIG,
     Auth,
     Changes,
@@ -77,10 +78,11 @@ var feedback = require('../modules/feedback'),
     var ctrl = this;
     var mapStateToTarget = function(state) {
       return {
-        cancelCallback: state.cancelCallback
+        cancelCallback: state.cancelCallback,
+        enketoStatus: state.enketoStatus
       };
     };
-    var unsubscribe = $ngRedux.connect(mapStateToTarget)(ctrl);
+    var unsubscribe = $ngRedux.connect(mapStateToTarget, Actions)(ctrl);
 
     Session.init();
 
@@ -206,7 +208,6 @@ var feedback = require('../modules/feedback'),
     $scope.tours = [];
     $scope.baseUrl = Location.path;
     $scope.adminUrl = Location.adminPath;
-    $scope.enketoStatus = { saving: false };
     $scope.isAdmin = Session.isAdmin();
 
     if (
@@ -265,7 +266,7 @@ var feedback = require('../modules/feedback'),
       if (trans.to().name.split('.')[0] !== trans.from().name.split('.')[0]){
         $scope.clearSelection();
       }
-      if (!$scope.enketoStatus.edited){
+      if (!ctrl.enketoStatus.edited){
         return;
       }
       if (ctrl.cancelCallback){
@@ -291,11 +292,11 @@ var feedback = require('../modules/feedback'),
 
     // User wants to cancel current flow, or pressed back button, etc.
     $scope.navigationCancel = function() {
-      if ($scope.enketoStatus.saving) {
+      if (ctrl.enketoStatus.saving) {
         // wait for save to finish
         return;
       }
-      if (!$scope.enketoStatus.edited) {
+      if (!ctrl.enketoStatus.edited) {
         // form hasn't been modified - return immediately
         if (ctrl.cancelCallback) {
           ctrl.cancelCallback();
@@ -308,7 +309,7 @@ var feedback = require('../modules/feedback'),
         controller: 'NavigationConfirmCtrl',
         singleton: true,
       }).then(function() {
-        $scope.enketoStatus.edited = false;
+        ctrl.setEnketoEditedStatus(false);
         if (ctrl.cancelCallback) {
           ctrl.cancelCallback();
         }

--- a/webapp/src/js/directives/navigation.js
+++ b/webapp/src/js/directives/navigation.js
@@ -10,7 +10,8 @@ angular.module('inboxDirectives').directive('mmNavigation', function() {
       var ctrl = this;
       var mapStateToTarget = function(state) {
         return {
-          cancelCallback: state.cancelCallback
+          cancelCallback: state.cancelCallback,
+          enketoStatus: state.enketoStatus
         };
       };
       var unsubscribe = $ngRedux.connect(mapStateToTarget)(ctrl);

--- a/webapp/src/js/reducers/index.js
+++ b/webapp/src/js/reducers/index.js
@@ -1,6 +1,11 @@
 (function() {
   var initialState = {
-    cancelCallback: null
+    cancelCallback: null,
+    enketoStatus: {
+      edited: false,
+      saving: false,
+      error: null
+    }
   };
 
   module.exports = function(state, action) {
@@ -11,6 +16,18 @@
     switch (action.type) {
       case 'SET_CANCEL_CALLBACK':
         return Object.assign({}, state, { cancelCallback: action.payload.cancelCallback });
+      case 'SET_ENKETO_ERROR':
+        return Object.assign({}, state, {
+          enketoStatus: Object.assign({}, state.enketoStatus, { error: action.payload.error })
+        });
+      case 'SET_ENKETO_EDITED_STATUS':
+        return Object.assign({}, state, {
+          enketoStatus: Object.assign({}, state.enketoStatus, { edited: action.payload.edited })
+        });
+      case 'SET_ENKETO_SAVING_STATUS':
+        return Object.assign({}, state, {
+          enketoStatus: Object.assign({}, state.enketoStatus, { saving: action.payload.saving })
+        });
       default:
         return state;
     }

--- a/webapp/src/js/router.js
+++ b/webapp/src/js/router.js
@@ -53,6 +53,7 @@
         views: {
           content: {
             controller: 'ReportsAddCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/reports_add.html'
           }
         }
@@ -65,6 +66,7 @@
         views: {
           content: {
             controller: 'ReportsAddCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/reports_add.html'
           }
         }
@@ -131,6 +133,7 @@
         views: {
           content: {
             controller: 'ContactsEditCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/contacts_edit.html'
           }
         }
@@ -144,6 +147,7 @@
         views: {
           content: {
             controller: 'ContactsReportCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/contacts_report.html'
           }
         }
@@ -181,6 +185,7 @@
         views: {
           content: {
             controller: 'ContactsEditCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/contacts_edit.html'
           }
         }
@@ -193,6 +198,7 @@
         views: {
           content: {
             controller: 'ContactsEditCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/contacts_edit.html'
           }
         }
@@ -212,6 +218,7 @@
         views: {
           content: {
             controller: 'TasksContentCtrl',
+            controllerAs: '$ctrl',
             templateUrl: 'templates/partials/tasks_content.html'
           }
         }

--- a/webapp/src/templates/directives/navigation.html
+++ b/webapp/src/templates/directives/navigation.html
@@ -1,6 +1,6 @@
 <div class="right-pane navigation">
   <a ng-show="$ctrl.cancelCallback" ng-click="navigationCancel()" class="filter-bar-back">
-    <span class="fa fa-times" ng-class="{ 'mm-icon-disabled': enketoStatus.saving }" translate translate-attr-title="close"></span>
+    <span class="fa fa-times" ng-class="{ 'mm-icon-disabled': $ctrl.enketoStatus.saving }" translate translate-attr-title="close"></span>
   </a>
   <a ng-hide="$ctrl.cancelCallback" ng-click="clearSelected()" class="filter-bar-back">
     <span class="fa fa-chevron-left" translate translate-attr-title="Back"></span>

--- a/webapp/src/templates/partials/contacts_edit.html
+++ b/webapp/src/templates/partials/contacts_edit.html
@@ -9,7 +9,7 @@
   </div>
   <div class="col-sm-8 item-content material" ng-show="!loadingContent && !contentError">
     <div class="card">
-      <mm-enketo id="'contact-form'" editing="enketoContact.docId" status="enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
+      <mm-enketo id="'contact-form'" editing="enketoContact.docId" status="$ctrl.enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
     </div>
   </div>
 </div>

--- a/webapp/src/templates/partials/contacts_report.html
+++ b/webapp/src/templates/partials/contacts_report.html
@@ -11,7 +11,7 @@
 
   <div class="col-sm-8 item-content material" ng-show="selected && form && !loadingForm">
     <div class="card">
-      <mm-enketo id="'contact-report'" status="enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
+      <mm-enketo id="'contact-report'" status="$ctrl.enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
     </div>
   </div>
 </div>

--- a/webapp/src/templates/partials/reports_add.html
+++ b/webapp/src/templates/partials/reports_add.html
@@ -11,7 +11,7 @@
 
   <div class="col-sm-8 item-content" ng-show="!loadingContent && !contentError">
     <div class="body">
-      <mm-enketo id="'report-form'" status="enketoStatus" on-submit="save()"on-cancel="navigationCancel()" />
+      <mm-enketo id="'report-form'" status="$ctrl.enketoStatus" on-submit="save()"on-cancel="navigationCancel()" />
     </div>
   </div>
 </div>

--- a/webapp/src/templates/partials/tasks_content.html
+++ b/webapp/src/templates/partials/tasks_content.html
@@ -47,7 +47,7 @@
 
   <div class="col-sm-8 item-content" ng-show="selected && form && !loadingContent && !loadingForm">
     <div class="body">
-      <mm-enketo id="'task-report'" status="enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
+      <mm-enketo id="'task-report'" status="$ctrl.enketoStatus" on-submit="save()" on-cancel="navigationCancel()" />
     </div>
   </div>
 </div>

--- a/webapp/tests/karma/unit/controllers/tasks-content.js
+++ b/webapp/tests/karma/unit/controllers/tasks-content.js
@@ -12,7 +12,10 @@ describe('TasksContentCtrl', function() {
   beforeEach(function() {
     render = sinon.stub();
     XmlForm = sinon.stub();
-    actions = { setCancelCallback: sinon.stub() };
+    actions = {
+      setCancelCallback: sinon.stub(),
+      setEnketoEditedStatus: sinon.stub()
+    };
     $scope = {
       $on: function() {},
       $watch: function(prop, cb) {
@@ -20,8 +23,7 @@ describe('TasksContentCtrl', function() {
       },
       setSelected: function() {
         $scope.selected = task;
-      },
-      enketoStatus: { edited: true }
+      }
     };
     render.returns(Promise.resolve());
     inject(function($controller) {
@@ -61,7 +63,8 @@ describe('TasksContentCtrl', function() {
       chai.expect(render.getCall(0).args[0]).to.equal('#task-report');
       chai.expect(render.getCall(0).args[1]).to.equal('myform');
       chai.expect(render.getCall(0).args[2]).to.equal('nothing');
-      chai.expect($scope.enketoStatus.edited).to.equal(false);
+      chai.expect(actions.setEnketoEditedStatus.callCount).to.equal(1);
+      chai.expect(actions.setEnketoEditedStatus.getCall(0).args[0]).to.equal(false);
       done();
     });
   });


### PR DESCRIPTION
# Description

Continuing on from [this PR](https://github.com/medic/medic/pull/5323), moving scope properties to the redux store

medic/medic#4750

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
