### PR TITLE
Adds support for sending messages to specific phone numbers.

### DIFF
--- a/shared-libs/message-utils/package-lock.json
+++ b/shared-libs/message-utils/package-lock.json
@@ -1,9 +1,18 @@
 {
   "name": "@medic/message-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@medic/phone-number": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@medic/phone-number/-/phone-number-1.0.0.tgz",
+      "integrity": "sha512-pGzrCnlxGUm9sjnwyzUxAtWZLYfLI4K+gZ0JDLuO2Yv2D0+nSTwDbLSc/jwkoWTU0pPwMXTro56fo4f6RcXE2Q==",
+      "dev": true,
+      "requires": {
+        "google-libphonenumber": "^3.2.1"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -144,6 +153,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "google-libphonenumber": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.2.tgz",
+      "integrity": "sha512-ubjGeosYPeusjYbUHy76lCniGTTI0k1rIFc+uKBX+jHQLDmWOSUtlFUxaeoLJ+Y+PAMM6dWp+C1HjHx5BI8kEw==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",

--- a/shared-libs/message-utils/package.json
+++ b/shared-libs/message-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medic/message-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.js",
   "scripts": {
     "test": "mocha ./test"
@@ -8,6 +8,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@medic/phone-number": "1.0.0",
     "bikram-sambat-bootstrap": "^1.4.2",
     "chai": "^4.2.0",
     "gsm": "^0.1.4",

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -5,6 +5,7 @@ var _ = require('underscore'),
     objectPath = require('object-path'),
     moment = require('moment'),
     toBikramSambatLetters = require('bikram-sambat').toBik_text,
+    phoneNumber = require('@medic/phone-number'),
     SMS_TRUNCATION_SUFFIX = '...';
 
 var getParent = function(doc, type) {
@@ -101,6 +102,9 @@ var getRecipient = function(context, recipient) {
   } else if (recipient.indexOf('.') > -1) {
     // Or multiple layers by executing it as a statement
     phone = objectPath.get(context, recipient);
+  } else if (phoneNumber.validate({ phone_validation: 'partial' }, recipient)) {
+    // or a specific phone number
+    phone = recipient;
   }
   return phone || from || recipient;
 };

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -102,7 +102,7 @@ var getRecipient = function(context, recipient) {
   } else if (recipient.indexOf('.') > -1) {
     // Or multiple layers by executing it as a statement
     phone = objectPath.get(context, recipient);
-  } else if (phoneNumber.validate({ phone_validation: 'partial' }, recipient)) {
+  } else if (phoneNumber.validate({}, recipient)) {
     // or a specific phone number
     phone = recipient;
   }

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -118,6 +118,12 @@ describe('messageUtils', () => {
       utils._getRecipient({foo: {bar: {smang: 'baz'}}}, 'foo.bar.smang')
         .should.equal('baz');
     });
+    it('should return the recipient if it is a valid phone number', () => {
+      utils._getRecipient({ from: 'martha' }, '+40211565656').should.equal('+40211565656');
+      utils._getRecipient({ from: 'martha' }, '+10789212558').should.equal('+10789212558');
+      utils._getRecipient({ from: 'martha' }, '123').should.equal('martha');
+      utils._getRecipient({ from: 'martha' }, '99999').should.equal('martha');
+    });
     it('returns doc.from if the recipient cannot be resolved', () => {
       utils._getRecipient({from: 'foo'}, 'a-recipient')
         .should.equal('foo');

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -118,9 +118,12 @@ describe('messageUtils', () => {
       utils._getRecipient({foo: {bar: {smang: 'baz'}}}, 'foo.bar.smang')
         .should.equal('baz');
     });
-    it('should return the recipient if it is a valid phone number', () => {
-      utils._getRecipient({ from: 'martha' }, '+40211565656').should.equal('+40211565656');
-      utils._getRecipient({ from: 'martha' }, '+10789212558').should.equal('+10789212558');
+    it('should return the provided recipient if it is a valid phone number', () => {
+      utils._getRecipient({ from: 'martha' }, '+26339262897').should.equal('+26339262897'); // zimbabwe
+      utils._getRecipient({ from: 'martha' }, '+33470075051').should.equal('+33470075051'); // france
+      utils._getRecipient({ from: 'martha' }, '+254202244150').should.equal('+254202244150'); // kenya
+      utils._getRecipient({ from: 'martha' }, '+9771-4492163').should.equal('+9771-4492163'); // nepal
+      utils._getRecipient({ from: 'martha' }, '+10789212558').should.equal('martha'); // random numbers
       utils._getRecipient({ from: 'martha' }, '123').should.equal('martha');
       utils._getRecipient({ from: 'martha' }, '99999').should.equal('martha');
     });


### PR DESCRIPTION
# Description

If provided with a valid phone number recipient, message-utils should use that as a `to` field instead of defaulting to the sender (`from`). 
Certain transitions (like `accept_patient_reports`) support including an explicit phone number as message recipient, while `multi_report_alerts` always passes explicit phone numbers when generating messages. 

medic/medic#5369

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
