### PR TITLE
Fix a bug where edit translation failed silently

### DIFF
--- a/admin/src/css/configuration.less
+++ b/admin/src/css/configuration.less
@@ -188,3 +188,8 @@ dl.horizontal {
     }
   }
 }
+
+.translations .missing-term {
+  font-style: italic;
+  color: @label-color;
+}

--- a/admin/src/css/theme.less
+++ b/admin/src/css/theme.less
@@ -106,10 +106,6 @@ ul {
   list-style-type: none;
   padding: 0;
 }
-.form-group.required label::after {
-  content: '*';
-  margin-left: 5px;
-}
 
 .loader {
   margin: 10px auto;

--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -40,7 +40,7 @@ angular.module('controllers').controller('EditTranslationCtrl',
           if (!locale.custom) {
             locale.custom = {};
           }
-          locale.custom[$scope.model.key] = newValue || undefined;
+          locale.custom[$scope.model.key] = newValue || null;
           return true;
         }
         return false;

--- a/admin/src/js/controllers/edit-translation.js
+++ b/admin/src/js/controllers/edit-translation.js
@@ -28,19 +28,19 @@ angular.module('controllers').controller('EditTranslationCtrl',
     var getUpdatedLocales = function() {
       return _.filter($scope.model.locales, function(locale) {
         const newValue = $scope.model.values[locale.code];
-        const custom = locale.custom || {};
+        const custom = locale.custom && locale.custom[$scope.model.key];
+        const generic = locale.generic && locale.generic[$scope.model.key];
+
         if (
-          !$scope.editing ||
-          (
-            $scope.editing &&                          // editing
-            (newValue || custom[$scope.model.key]) &&  // assigning or removing a value
-            custom[$scope.model.key] !== newValue      // different from current
-          )
+          (!$scope.editing) || // adding a new translation key
+          (custom && !newValue) || // deleting a custom term
+          (custom && custom !== newValue) || // updating a custom term
+          (!custom && newValue && newValue !== generic) // adding a custom term
         ) {
           if (!locale.custom) {
             locale.custom = {};
           }
-          locale.custom[$scope.model.key] = newValue;
+          locale.custom[$scope.model.key] = newValue || undefined;
           return true;
         }
         return false;

--- a/admin/src/templates/edit_translation.html
+++ b/admin/src/templates/edit_translation.html
@@ -10,9 +10,10 @@
   show-delete="isCustom"
 >
   <form action="" method="POST">
-    <div class="form-group">
+    <div class="form-group" ng-class="{ required: !editing }">
       <label translate>translation.key</label>
       <input class="form-control" ng-model="model.key" ng-disabled="editing">
+      <span class="error" ng-if="errors.key">{{errors.key}}</span>
     </div>
     <div class="form-group" ng-repeat="locale in model.locales track by locale._id">
       <label>{{locale.name}}</label>

--- a/admin/src/templates/translation_application.html
+++ b/admin/src/templates/translation_application.html
@@ -4,7 +4,7 @@
     <span translate>translation.add</span>
   </a>
 </div>
-<div class="section">
+<div class="section translations">
   <div class="container-fluid">
     <div class="row selection-heading">
       <div class="col-xs-6">
@@ -18,10 +18,12 @@
   <div class="container-fluid">
     <div class="row translation selection" ng-repeat="translation in translationModels track by translation.key" ng-click="editTranslation(translation.key)">
       <div class="col-xs-6">
-        {{translation.lhs}}
+        <span ng-if="translation.lhs">{{translation.lhs}}</span>
+        <span ng-if="!translation.lhs" class="missing-term">{{translation.key}}</span>
       </div>
       <div class="col-xs-6">
-        {{translation.rhs}}
+        <span ng-if="translation.rhs">{{translation.rhs}}</span>
+        <span ng-if="!translation.rhs" class="missing-term">{{translation.key}}</span>
       </div>
     </div>
   </div>

--- a/admin/tests/unit/controllers/edit-translation.js
+++ b/admin/tests/unit/controllers/edit-translation.js
@@ -144,7 +144,7 @@ describe('EditTranslationCtrl controller', function() {
       chai.expect(updated[1].code).to.equal('fr');
       chai.expect(updated[1].custom.somethingelse).to.equal('b');
       chai.expect(updated[2].code).to.equal('es');
-      chai.expect(updated[2].custom.somethingelse).to.equal(undefined);
+      chai.expect(updated[2].custom.somethingelse).to.equal(null);
       done();
     });
   });

--- a/admin/tests/unit/controllers/edit-translation.js
+++ b/admin/tests/unit/controllers/edit-translation.js
@@ -78,6 +78,7 @@ describe('EditTranslationCtrl controller', function() {
     createController();
     scope.model.values.en = 'Hello';
     scope.model.values.fr = 'Bienvenue';
+    scope.model.values.es = 'Hola';
     scope.submit();
     setTimeout(function() {
       rootScope.$digest();
@@ -87,6 +88,35 @@ describe('EditTranslationCtrl controller', function() {
       chai.expect(updated[0].custom['title.key']).to.equal('Hello');
       chai.expect(updated[1].code).to.equal('fr');
       chai.expect(updated[1].custom['title.key']).to.equal('Bienvenue');
+      done();
+    });
+  });
+
+  it('save custom', function(done) {
+    model = {
+      key: 'title.key',
+      locales: [
+        { doc: { code: 'en', custom: { 'title.key': 'Welcome', 'bye': 'Goodbye' } } },
+        { doc: { code: 'fr', custom: { 'title.key': 'Bonjour', 'bye': 'Au revoir' } } },
+        { doc: { code: 'es', custom: { 'title.key': '', 'bye': 'Hasta luego' } } }
+      ]
+    };
+    bulkDocs.returns(Promise.resolve());
+    createController();
+    scope.model.values.en = 'Hello';
+    scope.model.values.fr = 'Bienvenue';
+    scope.model.values.es = 'Hola';
+    scope.submit();
+    setTimeout(function() {
+      rootScope.$digest();
+      var updated = bulkDocs.args[0][0];
+      chai.expect(updated.length).to.equal(3);
+      chai.expect(updated[0].code).to.equal('en');
+      chai.expect(updated[0].custom['title.key']).to.equal('Hello');
+      chai.expect(updated[1].code).to.equal('fr');
+      chai.expect(updated[1].custom['title.key']).to.equal('Bienvenue');
+      chai.expect(updated[2].code).to.equal('es');
+      chai.expect(updated[2].custom['title.key']).to.equal('Hola');
       done();
     });
   });
@@ -114,7 +144,7 @@ describe('EditTranslationCtrl controller', function() {
       chai.expect(updated[1].code).to.equal('fr');
       chai.expect(updated[1].custom.somethingelse).to.equal('b');
       chai.expect(updated[2].code).to.equal('es');
-      chai.expect(updated[2].custom.somethingelse).to.equal(null);
+      chai.expect(updated[2].custom.somethingelse).to.equal(undefined);
       done();
     });
   });

--- a/webapp/src/css/common.less
+++ b/webapp/src/css/common.less
@@ -5,3 +5,36 @@
     margin: 40px;
   }
 }
+
+.form-group.required label::after {
+  content: '*';
+  margin-left: 5px;
+}
+
+.form-actions,
+.form-group,
+.form-footer {
+  .error {
+    color: @error-color;
+    font-weight: bold;
+  }
+}
+.form-footer .error {
+  text-align: right;
+  clear: right;
+}
+.form-actions {
+  line-height: 20px;
+  .success {
+    display: inline-block !important;
+    opacity: 1;
+    transition: all linear 0s;
+    &.ng-hide, &.ng-hide-add.ng-hide-add-active {
+      opacity: 0;
+    }
+    &.ng-hide-add {
+      transition: all linear 1s;
+      opacity: 1;
+    }
+  }
+}

--- a/webapp/src/css/theme.less
+++ b/webapp/src/css/theme.less
@@ -43,39 +43,6 @@ a {
   }
 }
 
-.form-group.required label::after {
-  content: '*';
-  margin-left: 5px;
-}
-
-.form-actions,
-.form-group,
-.form-footer {
-  .error {
-    color: @error-color;
-    font-weight: bold;
-  }
-}
-.form-footer .error {
-  text-align: right;
-  clear: right;
-}
-.form-actions {
-  line-height: 20px;
-  .success {
-    display: inline-block !important;
-    opacity: 1;
-    transition: all linear 0s;
-    &.ng-hide, &.ng-hide-add.ng-hide-add-active {
-      opacity: 0;
-    }
-    &.ng-hide-add {
-      transition: all linear 1s;
-      opacity: 1;
-    }
-  }
-}
-
 .fa-stack.default {
   font-size: 7px;
   .fa-star {


### PR DESCRIPTION
Also makes the translation key required when adding a translation.
Also changes the translation list to show the key with styling when the translation is missing for that key.

medic/medic#5405
medic/medic#5120
medic/medic#5121

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
