### PR TITLE
Adds Sentinel e2e tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -452,7 +452,7 @@ module.exports = function(grunt) {
       },
       'reset-test-databases': {
         stderr: false,
-        cmd: ['medic-test', 'medic-test-audit', 'medic-test-user-admin-meta']
+        cmd: ['medic-test', 'medic-test-audit', 'medic-test-user-admin-meta', 'medic-test-sentinel']
           .map(
             name => `curl -X DELETE ${couchConfig.withPath(name)}`
           )

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -412,8 +412,7 @@ describe('accept_patient_reports', () => {
       });
   });
 
-  // these tests fail cause of write conflicts when trying to silence registrations
-  xit('should silence registrations', () => {
+  it('should silence registrations', () => {
     const settings = {
       transitions: { accept_patient_reports: true },
       patient_reports: [

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -557,11 +557,12 @@ describe('accept_patient_reports', () => {
       .then(() => utils.getDocs(registrations.map(r => r._id)))
       .then(updated => {
         console.log(require('util').inspect(updated[0], { depth: 100 }));
-
         expect(updated[0].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
         expect(updated[0].scheduled_tasks.find(task => task.id === 2).state).toEqual('cleared');
-        expect(updated[0].scheduled_tasks.find(task => task.id === 3).state).toEqual('pending');
-        expect(updated[0].scheduled_tasks.find(task => task.id === 4).state).toEqual('sent');
+        // this task was scheduled in the future, is getting cleared because of the sent task from below
+        expect(updated[0].scheduled_tasks.find(task => task.id === 3).state).toEqual('cleared');
+        // this task is sent and has a due date in the past, but it still clears all other tasks of the same type
+        expect(updated[0].scheduled_tasks.find(task => task.id === 4).state).toEqual('cleared');
         expect(updated[0].scheduled_tasks.find(task => task.id === 5).state).toEqual('muted');
 
         expect(updated[1].scheduled_tasks.find(task => task.id === 1 && task.group === 'a').state).toEqual('scheduled');

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -1,0 +1,595 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+
+const contacts = [
+  {
+    _id: 'district_hospital',
+    name: 'District hospital',
+    type: 'district_hospital',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'health_center',
+    name: 'Health Center',
+    type: 'health_center',
+    parent: { _id: 'district_hospital' },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person',
+    name: 'Person',
+    type: 'person',
+    patient_id: 'patient',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+phone',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person2',
+    name: 'Person',
+    type: 'person',
+    patient_id: 'patient2',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+phone2',
+    reported_date: new Date().getTime()
+  }
+];
+
+describe('accept_patient_reports', () => {
+  beforeAll(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { accept_patient_reports: false },
+      patient_reports: [{ form: 'FORM' }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999'
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped when no matching config', () => {
+    const settings = {
+      transitions: { accept_patient_reports: false },
+      patient_reports: [{ form: 'FORM' }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'NOT_FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999'
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should add errors when patient not found or validation does not pass', () => {
+    const settings = {
+      transitions: { accept_patient_reports: true },
+      patient_reports: [
+        {
+          form: 'FORM',
+          validations: {
+            list: [
+              {
+                property: 'patient_id',
+                rule: 'lenMin(5) && lenMax(10)',
+                message: [{
+                  locale: 'en',
+                  content: 'Patient id incorrect'
+                }],
+              },
+            ],
+            join_responses: false
+          },
+          messages: [{
+            event_type: 'registration_not_found',
+            message: [{
+              locale: 'en',
+              content: 'Patient not found'
+            }],
+          }]
+        }
+      ]
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: 'phone',
+      fields: {
+        patient_id: 'unknown'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: 'phone',
+      fields: {
+        patient_id: 'this will not match the validation rule'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([doc1, doc2]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.accept_patient_reports).toBeDefined();
+        expect(infos[0].transitions.accept_patient_reports.ok).toBe(true);
+
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.accept_patient_reports).toBeDefined();
+        expect(infos[1].transitions.accept_patient_reports.ok).toBe(true);
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Patient not found');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('phone');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[0].errors).toBeDefined();
+        expect(updated[0].errors.length).toEqual(1);
+        expect(updated[0].errors[0].code).toEqual('registration_not_found');
+
+        expect(updated[1].tasks).toBeDefined();
+        expect(updated[1].tasks.length).toEqual(1);
+        expect(updated[1].tasks[0].messages[0].message).toEqual('Patient id incorrect');
+        expect(updated[1].tasks[0].messages[0].to).toEqual('phone');
+        expect(updated[1].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].errors).toBeDefined();
+        expect(updated[1].errors.length).toEqual(1);
+        expect(updated[1].errors[0].message).toEqual('Patient id incorrect');
+      });
+  });
+
+  it('should add relevant messages', () => {
+    const settings = {
+      transitions: { accept_patient_reports: true },
+      patient_reports: [
+        {
+          form: 'FORM',
+          messages: [
+            {
+              event_type: 'registration_not_found',
+              message: [{
+                locale: 'en',
+                content: 'Patient not found'
+              }],
+            },
+            {
+              event_type: 'report_accepted',
+              recipient: 'recipient_1',
+              message: [{
+                locale: 'en',
+                content: 'message_1'
+              }],
+            },
+            {
+              event_type: 'report_accepted',
+              recipient: 'recipient_2',
+              bool_expr: 'doc.type === "data_record"',
+              message: [{
+                locale: 'en',
+                content: 'message_2'
+              }],
+            },
+            {
+              event_type: 'report_accepted',
+              recipient: 'recipient_3',
+              bool_expr: 'doc.fields.something === true',
+              message: [{
+                locale: 'en',
+                content: 'message_3'
+              }],
+            }
+          ]
+        }
+      ]
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: 'phone',
+      fields: {
+        patient_id: 'patient'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: 'phone2',
+      fields: {
+        patient_id: 'patient2',
+        something: true
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([doc1, doc2]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.accept_patient_reports).toBeDefined();
+        expect(infos[0].transitions.accept_patient_reports.ok).toBe(true);
+
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.accept_patient_reports).toBeDefined();
+        expect(infos[1].transitions.accept_patient_reports.ok).toBe(true);
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(2);
+
+        expect(updated[0].tasks[0].messages[0].message).toEqual('message_1');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('phone');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[0].tasks[1].messages[0].message).toEqual('message_2');
+        expect(updated[0].tasks[1].messages[0].to).toEqual('phone');
+        expect(updated[0].tasks[1].state).toEqual('pending');
+
+        expect(updated[0].errors).not.toBeDefined();
+        expect(updated[0].registration_id).not.toBeDefined();
+
+        expect(updated[1].tasks).toBeDefined();
+        expect(updated[1].tasks.length).toEqual(3);
+
+        expect(updated[1].tasks[0].messages[0].message).toEqual('message_1');
+        expect(updated[1].tasks[0].messages[0].to).toEqual('phone2');
+        expect(updated[1].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].tasks[1].messages[0].message).toEqual('message_2');
+        expect(updated[1].tasks[1].messages[0].to).toEqual('phone2');
+        expect(updated[1].tasks[1].state).toEqual('pending');
+
+        expect(updated[1].tasks[2].messages[0].message).toEqual('message_3');
+        expect(updated[1].tasks[2].messages[0].to).toEqual('phone2');
+        expect(updated[1].tasks[2].state).toEqual('pending');
+
+        expect(updated[1].errors).not.toBeDefined();
+        expect(updated[1].registration_id).not.toBeDefined();
+      });
+  });
+
+  it('should add registration to doc', () => {
+    const settings = {
+      transitions: { accept_patient_reports: true },
+      patient_reports: [{ form: 'FORM', messages: [] }],
+      registrations: [{ form: 'xml_form' }, { form: 'sms_form_1' }, { form: 'sms_form_2' }],
+      forms: { sms_form_1: { public_form: true }, sms_form_2: { public_form: false } }
+    };
+
+    const reports = [
+      { // not a registration
+        _id: 'no_registration_config',
+        type: 'data_record',
+        content_type: 'xml',
+        form: 'test_form',
+        fields: {
+          patient_id: 'patient'
+        },
+        reported_date: new Date().getTime()
+      },
+      { // not a registration
+        _id: 'incorrect_content',
+        type: 'data_record',
+        form: 'xml_form',
+        fields: {
+          patient_id: 'patient'
+        },
+        reported_date: new Date().getTime() + 5000
+      },
+      { // not a registration
+        _id: 'sms_without_contact',
+        type: 'data_record',
+        form: 'sms_form_2',
+        fields: {
+          patient_id: 'person'
+        },
+        reported_date: new Date().getTime() + 6000
+      },
+      { // valid registration
+        _id: 'registration_1',
+        type: 'data_record',
+        content_type: 'xml',
+        form: 'xml_form',
+        fields: {
+          patient_id: 'patient'
+        },
+        reported_date: new Date().getTime() + 1000
+      },
+      { // valid registration
+        _id: 'registration_2',
+        type: 'data_record',
+        form: 'sms_form_1',
+        fields: {
+          patient_id: 'patient'
+        },
+        reported_date: new Date().getTime() + 3000
+      },
+      { // valid registration
+        _id: 'registration_3',
+        type: 'data_record',
+        form: 'sms_form_2',
+        fields: {
+          patient_id: 'patient'
+        },
+        contact: { _id: 'person' },
+        reported_date: new Date().getTime()
+      },
+      { // valid registration for other patient
+        _id: 'registration_4',
+        type: 'data_record',
+        form: 'sms_form_2',
+        fields: {
+          patient_id: 'patient2'
+        },
+        contact: { _id: 'person2' },
+        reported_date: new Date().getTime() + 1000
+      }
+    ];
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: 'phone2',
+      fields: {
+        patient_id: 'patient',
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs(reports))
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.accept_patient_reports).toBeDefined();
+        expect(info.transitions.accept_patient_reports.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.registration_id).toEqual('registration_2');
+      });
+  });
+
+  it('should silence registrations', () => {
+    const settings = {
+      transitions: { accept_patient_reports: true },
+      patient_reports: [
+        {
+          form: 'NO_SILENCE',
+          messages: [],
+          silence_for: '',
+          silence_type: ''
+        },
+        {
+          form: 'SILENCE1',
+          messages: [],
+          silence_for: '1 days',
+          silence_type: 'type1,type2'
+        },
+        {
+          form: 'SILENCE2',
+          messages: [],
+          silence_for: '',
+          silence_type: 'type3'
+        }
+      ],
+      registrations: [{ form: 'form_1' }, { form: 'form_2' }],
+      forms: { form_1: { public_form: true }, form_2: { public_form: true } }
+    };
+
+    const oneDay = 24 * 60 * 60 * 1000;
+
+    const registrations = [
+      {
+        _id: uuid(),
+        form: 'form_1',
+        fields: { patient_id: 'patient' },
+        type: 'data_record',
+        reported_date: new Date().getTime(),
+        scheduled_tasks: [
+          { id: 1, type: 'type0', state: 'scheduled', due: new Date().getTime() + 10 * oneDay },
+          { id: 2, type: 'type1', state: 'scheduled', due: new Date().getTime() - 2 * oneDay },
+          { id: 3, type: 'type2', state: 'pending', due: new Date().getTime() + 3 * oneDay },
+          { id: 4, type: 'type2', state: 'sent', due: new Date().getTime() - 10 * oneDay },
+          { id: 5, type: 'type3', state: 'muted', due: new Date().getTime() - 10 * oneDay },
+        ]
+      },
+      {
+        _id: uuid(),
+        form: 'form_2',
+        fields: { patient_id: 'patient' },
+        type: 'data_record',
+        reported_date: new Date().getTime(),
+        scheduled_tasks: [
+          { id: 1, type: 'type0', group: 'a', state: 'scheduled', due: new Date().getTime() - 10 * oneDay },
+          { id: 2, type: 'type1', group: 'a', state: 'pending', due: new Date().getTime() - 10 * oneDay },
+          { id: 3, type: 'type1', group: 'a', state: 'scheduled', due: new Date().getTime() + 10 * oneDay },
+          { id: 4, type: 'type2', group: 'a', state: 'scheduled', due: new Date().getTime() + 2 * oneDay },
+          { id: 5, type: 'type2', group: 'a', state: 'pending', due: new Date().getTime() + 5 * oneDay },
+          { id: 6, type: 'type2', group: 'a', state: 'delivered', due: new Date().getTime() - 5 * oneDay },
+
+          { id: 1, type: 'type1', group: 'b', state: 'pending', due: new Date().getTime() + 10 * oneDay },
+          { id: 2, type: 'type2', group: 'b', state: 'scheduled', due: new Date().getTime() - 20 * oneDay },
+          { id: 3, type: 'type2', group: 'b', state: 'muted', due: new Date().getTime() + 2 * oneDay },
+          { id: 4, type: 'type2', group: 'b', state: 'sent', due: new Date().getTime() - 20 * oneDay },
+          { id: 5, type: 'type3', group: 'b', state: 'muted', due: new Date().getTime() + 1 * oneDay },
+        ]
+      },
+      {
+        _id: uuid(),
+        form: 'form_1',
+        fields: { patient_id: 'patient2' },
+        type: 'data_record',
+        reported_date: new Date().getTime(),
+        scheduled_tasks: [
+          { id: 1, type: 'type0', state: 'scheduled', due: new Date().getTime() + 10 * oneDay },
+          { id: 2, type: 'type1', state: 'pending', due: new Date().getTime() - 2 * oneDay },
+          { id: 3, type: 'type3', state: 'muted', due: new Date().getTime() - 10 * oneDay },
+          { id: 4, type: 'type3', state: 'muted', due: new Date().getTime() + 10 * oneDay },
+          { id: 5, type: 'type3', state: 'sent', due: new Date().getTime() - 10 * oneDay },
+        ]
+      },
+      {
+        _id: uuid(),
+        form: 'form_2',
+        fields: { patient_id: 'patient2' },
+        type: 'data_record',
+        reported_date: new Date().getTime(),
+        scheduled_tasks: [
+          { id: 1, type: 'type0', group: 'a', state: 'scheduled', due: new Date().getTime() - 10 * oneDay },
+          { id: 2, type: 'type3', group: 'a', state: 'pending', due: new Date().getTime() - 10 * oneDay },
+          { id: 3, type: 'type3', group: 'a', state: 'scheduled', due: new Date().getTime() + 10 * oneDay },
+
+          { id: 1, type: 'type1', group: 'b', state: 'pending', due: new Date().getTime() + 10 * oneDay },
+          { id: 2, type: 'type3', group: 'b', state: 'muted', due: new Date().getTime() + 2 * oneDay },
+          { id: 3, type: 'type3', group: 'b', state: 'muted', due: new Date().getTime() + 1 * oneDay },
+        ]
+      }
+    ];
+
+    const noSilence = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'NO_SILENCE',
+      from: 'phone',
+      fields: {
+        patient_id: 'patient',
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const silence1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'SILENCE1',
+      from: 'phone',
+      fields: {
+        patient_id: 'patient',
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const silence2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'SILENCE2',
+      from: 'phone',
+      fields: {
+        patient_id: 'patient2',
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs(registrations))
+      .then(() => utils.saveDoc(noSilence))
+      .then(() => sentinelUtils.waitForSentinel(noSilence._id))
+      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(updated => {
+        // none of the scheduled tasks should be cleared
+        expect(updated.every(doc => !doc.scheduled_tasks.find(task => task.state === 'cleared'))).toBe(true);
+      })
+      .then(() => utils.saveDoc(silence1))
+      .then(() => sentinelUtils.waitForSentinel(silence1._id))
+      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(updated => {
+        console.log(require('util').inspect(updated[0], { depth: 100 }));
+
+        expect(updated[0].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
+        expect(updated[0].scheduled_tasks.find(task => task.id === 2).state).toEqual('cleared');
+        expect(updated[0].scheduled_tasks.find(task => task.id === 3).state).toEqual('pending');
+        expect(updated[0].scheduled_tasks.find(task => task.id === 4).state).toEqual('sent');
+        expect(updated[0].scheduled_tasks.find(task => task.id === 5).state).toEqual('muted');
+
+        expect(updated[1].scheduled_tasks.find(task => task.id === 1 && task.group === 'a').state).toEqual('scheduled');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 2 && task.group === 'a').state).toEqual('cleared');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 3 && task.group === 'a').state).toEqual('cleared');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 4 && task.group === 'a').state).toEqual('scheduled');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 5 && task.group === 'a').state).toEqual('pending');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 6 && task.group === 'a').state).toEqual('delivered');
+
+        expect(updated[1].scheduled_tasks.find(task => task.id === 1 && task.group === 'b').state).toEqual('pending');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 2 && task.group === 'b').state).toEqual('cleared');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 3 && task.group === 'b').state).toEqual('cleared');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 4 && task.group === 'b').state).toEqual('sent');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 5 && task.group === 'b').state).toEqual('muted');
+
+        expect(updated[2].scheduled_tasks).toEqual(registrations[2].scheduled_tasks);
+        expect(updated[3].scheduled_tasks).toEqual(registrations[3].scheduled_tasks);
+      })
+      .then(() => utils.saveDoc(silence2))
+      .then(() => sentinelUtils.waitForSentinel(noSilence._id))
+      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(updated => {
+        expect(updated[2].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
+        expect(updated[2].scheduled_tasks.find(task => task.id === 2).state).toEqual('cleared');
+        expect(updated[2].scheduled_tasks.find(task => task.id === 3).state).toEqual('cleared');
+        expect(updated[2].scheduled_tasks.find(task => task.id === 4).state).toEqual('muted');
+        expect(updated[2].scheduled_tasks.find(task => task.id === 5).state).toEqual('sent');
+      })
+  });
+
+});

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -597,5 +597,4 @@ describe('accept_patient_reports', () => {
         expect(updated[3].scheduled_tasks.find(task => task.id === 3 && task.group === 'b').state).toEqual('sent');
       });
   });
-
 });

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -559,26 +559,21 @@ describe('accept_patient_reports', () => {
       .then(updated => {
         expect(updated[0].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
         expect(updated[0].scheduled_tasks.find(task => task.id === 2).state).toEqual('cleared');
-        // this task was scheduled in the future, is getting cleared because of the sent task from below
         expect(updated[0].scheduled_tasks.find(task => task.id === 3).state).toEqual('cleared');
-        // this task is sent and has a due date in the past, but it still clears all other tasks of the same type
-        expect(updated[0].scheduled_tasks.find(task => task.id === 4).state).toEqual('cleared');
+        expect(updated[0].scheduled_tasks.find(task => task.id === 4).state).toEqual('sent');
         expect(updated[0].scheduled_tasks.find(task => task.id === 5).state).toEqual('muted');
 
         expect(updated[1].scheduled_tasks.find(task => task.id === 1 && task.group === 'a').state).toEqual('scheduled');
         expect(updated[1].scheduled_tasks.find(task => task.id === 2 && task.group === 'a').state).toEqual('cleared');
         expect(updated[1].scheduled_tasks.find(task => task.id === 3 && task.group === 'a').state).toEqual('cleared');
-        // all these tasks get cleared because of the delivered one with the due date in the past
-        // none of these should be cleared theoretically?
         expect(updated[1].scheduled_tasks.find(task => task.id === 4 && task.group === 'a').state).toEqual('cleared');
         expect(updated[1].scheduled_tasks.find(task => task.id === 5 && task.group === 'a').state).toEqual('cleared');
-        expect(updated[1].scheduled_tasks.find(task => task.id === 6 && task.group === 'a').state).toEqual('cleared');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 6 && task.group === 'a').state).toEqual('delivered');
 
         expect(updated[1].scheduled_tasks.find(task => task.id === 1 && task.group === 'b').state).toEqual('pending');
         expect(updated[1].scheduled_tasks.find(task => task.id === 2 && task.group === 'b').state).toEqual('cleared');
         expect(updated[1].scheduled_tasks.find(task => task.id === 3 && task.group === 'b').state).toEqual('cleared');
-        // this task should retain it's sent state
-        expect(updated[1].scheduled_tasks.find(task => task.id === 4 && task.group === 'b').state).toEqual('cleared');
+        expect(updated[1].scheduled_tasks.find(task => task.id === 4 && task.group === 'b').state).toEqual('sent');
         expect(updated[1].scheduled_tasks.find(task => task.id === 5 && task.group === 'b').state).toEqual('muted');
 
         expect(updated[2].scheduled_tasks).toEqual(registrations[2].scheduled_tasks);

--- a/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
@@ -77,7 +77,7 @@ describe('conditional_alerts', () => {
       });
   });
 
-  it('should be skipped when enabled but have no matching config', () => {
+  it('should be skipped when no matching config', () => {
     const settings = {
       transitions: { conditional_alerts: true },
       alerts: [{
@@ -95,8 +95,6 @@ describe('conditional_alerts', () => {
       reported_date: new Date().getTime(),
       from: '+444999'
     };
-
-    console.log('aiiici');
 
     return utils
       .updateSettings(settings, true)

--- a/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
@@ -73,7 +73,7 @@ describe('conditional_alerts', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       });
   });
 
@@ -102,7 +102,7 @@ describe('conditional_alerts', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       });
   });
 
@@ -133,7 +133,7 @@ describe('conditional_alerts', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       });
   });
 
@@ -174,6 +174,7 @@ describe('conditional_alerts', () => {
         expect(updated.tasks.length).toEqual(1);
         expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
         expect(updated.tasks[0].messages[0].message).toEqual('This is an alert');
+        expect(updated.tasks[0].state).toEqual('pending');
       });
   });
 
@@ -229,6 +230,7 @@ describe('conditional_alerts', () => {
         expect(updated.tasks.length).toEqual(1);
         expect(updated.tasks[0].messages[0].to).toEqual(form1.from);
         expect(updated.tasks[0].messages[0].message).toEqual('Patient has a fever');
+        expect(updated.tasks[0].state).toEqual('pending');
       })
       .then(() => utils.saveDoc(form0))
       .then(() => sentinelUtils.waitForSentinel(form0._id))
@@ -244,6 +246,7 @@ describe('conditional_alerts', () => {
         expect(updated.tasks.length).toEqual(1);
         expect(updated.tasks[0].messages[0].to).toEqual(form0.from);
         expect(updated.tasks[0].messages[0].message).toEqual('Fever increased since the last measurement');
+        expect(updated.tasks[0].state).toEqual('pending');
       });
   });
 });

--- a/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
@@ -1,0 +1,277 @@
+const utils = require('../../../utils'),
+      querystring = require('querystring'),
+      uuid = require('uuid');
+
+const contacts = [
+  {
+    _id: 'district_hospital',
+    name: 'District hospital',
+    type: 'district_hospital',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'health_center',
+    name: 'Health Center',
+    type: 'health_center',
+    parent: { _id: 'district_hospital' },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person',
+    name: 'Person',
+    type: 'person',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+444999',
+    reported_date: new Date().getTime()
+  }
+];
+
+const DOCS_TO_KEEP = [
+  'district_hospital',
+  'health_center',
+  'clinic',
+  'person'
+];
+
+const waitForSentinel = docId => {
+  return utils
+    .requestOnSentinelTestDb('/_local/sentinel-meta-data')
+    .then(metaData => metaData.processed_seq)
+    .then(seq => {
+      const changeOpts = {
+        since: seq,
+        filter: '_doc_ids',
+        doc_ids: JSON.stringify([docId])
+      };
+      return utils.requestOnTestDb('/_changes?' + querystring.stringify(changeOpts));
+    })
+    .then(response => {
+      if (response.results && !response.results.length) {
+        // sentinel has caught up and processed our doc
+        return;
+      }
+
+      return new Promise(resolve => {
+        setTimeout(() => waitForSentinel(docId).then(resolve), 100);
+      });
+    });
+};
+
+const getInfoDoc = docId => {
+  return utils.requestOnSentinelTestDb('/' + docId + '-info');
+};
+
+describe('conditional_alerts', () => {
+  beforeAll(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { conditional_alerts: false },
+      alerts: [
+        {
+          form: 'FORM',
+          condition: true,
+          message: 'This is an alert',
+          recipient: 'reporting_unit'
+        }
+      ]
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999'
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => waitForSentinel(doc._id))
+      .then(() => getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when enabled but have no matching config', () => {
+    const settings = {
+      transitions: { conditional_alerts: true },
+      alerts: [{
+        form: 'FORM',
+        condition: true,
+        message: 'This is an alert',
+        recipient: 'reporting_unit'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'O',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999'
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => waitForSentinel(doc._id))
+      .then(() => getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when conditions are not met', () => {
+    const settings = {
+      transitions: { conditional_alerts: true },
+      alerts: [{
+        form: 'FORM',
+        condition: 'FORM(0).somefield > 100',
+        message: 'This is an alert',
+        recipient: 'reporting_unit'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999',
+      contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      somefield: 99
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => waitForSentinel(doc._id))
+      .then(() => getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      });
+  });
+
+  it('should add a task when conditions are met', () => {
+    const settings = {
+      transitions: { conditional_alerts: true },
+      alerts: [{
+        form: 'FORM',
+        condition: 'FORM(0).somefield > 100',
+        message: 'This is an alert',
+        recipient: 'reporting_unit'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999',
+      contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      somefield: 120
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => waitForSentinel(doc._id))
+      .then(() => getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.conditional_alerts).toBeDefined();
+        expect(info.transitions.conditional_alerts.ok).toBe(true);
+        return utils.getDoc(doc._id);
+      })
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+        expect(updated.tasks[0].messages[0].message).toEqual('This is an alert');
+      });
+  });
+
+  it('should add a task when condition is met and depends on multiple forms', () => {
+    const settings = {
+      transitions: { conditional_alerts: true },
+      alerts: [{
+        form: 'FORM',
+        condition: 'FORM(1) && FORM(0).temp > FORM(1).temp && 1000 < FORM(0).reported_date - FORM(1).reported_date < 10000',
+        message: 'Fever increased since the last measurement',
+        recipient: 'reporting_unit'
+      }, {
+        form: 'FORM',
+        condition: 'FORM(0).temp > 37 && (!FORM(1) || FORM(0).reported_date - FORM(1).reported_date > 10000)',
+        message: 'Patient has a fever',
+        recipient: 'reporting_unit'
+      }]
+    };
+
+    const form1 = {
+      _id: uuid(),
+      form: 'FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime() - 1200,
+      from: '+444999',
+      contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      temp: 38
+    };
+
+    const form0 = {
+      _id: uuid(),
+      form: 'FORM',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      from: '+444999',
+      contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      temp: 39
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(form1))
+      .then(() => waitForSentinel(form1._id))
+      .then(() => getInfoDoc(form1._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.conditional_alerts).toBeDefined();
+        expect(info.transitions.conditional_alerts.ok).toBe(true);
+        return utils.getDoc(form1._id);
+      })
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].to).toEqual(form1.from);
+        expect(updated.tasks[0].messages[0].message).toEqual('Patient has a fever');
+      })
+      .then(() => utils.saveDoc(form0))
+      .then(() => waitForSentinel(form0._id))
+      .then(() => getInfoDoc(form0._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.conditional_alerts).toBeDefined();
+        expect(info.transitions.conditional_alerts.ok).toBe(true);
+        return utils.getDoc(form0._id);
+      })
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].to).toEqual(form0.from);
+        expect(updated.tasks[0].messages[0].message).toEqual('Fever increased since the last measurement');
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
@@ -34,17 +34,10 @@ const contacts = [
   }
 ];
 
-const DOCS_TO_KEEP = [
-  'district_hospital',
-  'health_center',
-  'clinic',
-  'person'
-];
-
 describe('conditional_alerts', () => {
   beforeAll(done => utils.saveDocs(contacts).then(done));
   afterAll(done => utils.revertDb().then(done));
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+  afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
 
   it('should be skipped when transition is disabled', () => {
     const settings = {

--- a/tests/e2e/sentinel/transitions/death_reporting.spec.js
+++ b/tests/e2e/sentinel/transitions/death_reporting.spec.js
@@ -1,0 +1,224 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+const contacts = [{
+  _id: 'person',
+  type: 'person',
+  name: 'Person',
+  patient_id: '12345',
+  reported_date: new Date().getTime()
+}, {
+  _id: 'person2',
+  type: 'person',
+  name: 'Person',
+  patient_id: '98765',
+  reported_date: new Date().getTime()
+}];
+
+describe('death_reporting', () => {
+  beforeEach(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { death_reporting: false },
+      death_reporting: {
+        mark_deceased_forms: ['DEAD'],
+        undo_deceased_forms: ['UNDEAD'],
+        date_field: 'date'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'DEAD',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      fields: {
+        patient_id: 'person'
+      }
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc('person'))
+      .then(person => {
+        expect(person.date_of_death).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when enabled but have no matching config', () => {
+    const settings = {
+      transitions: { death_reporting: true },
+      death_reporting: {
+        mark_deceased_forms: ['DEAD'],
+        undo_deceased_forms: ['UNDEAD'],
+        date_field: 'date'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'MAYBE_DEAD',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      fields: {
+        patient_id: 'person'
+      }
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc('person'))
+      .then(person => {
+        expect(person.date_of_death).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when patient is not found', () => {
+    const settings = {
+      transitions: { death_reporting: true },
+      death_reporting: {
+        mark_deceased_forms: ['DEAD'],
+        undo_deceased_forms: ['UNDEAD'],
+        date_field: 'date'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'DEAD',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      fields: {
+        patient_id: 'other'
+      }
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc('person'))
+      .then(person => {
+        expect(person.date_of_death).toEqual(undefined);
+      });
+  });
+
+  it('should add date_of_death field to patient with patient_id', () => {
+    const settings = {
+      transitions: { death_reporting: true },
+      death_reporting: {
+        mark_deceased_forms: ['DEAD'],
+        undo_deceased_forms: ['UNDEAD'],
+        date_field: 'date'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'DEAD',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      fields: {
+        patient_id: '12345'
+      }
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.death_reporting).toBeDefined();
+        expect(info.transitions.death_reporting.ok).toEqual(true);
+      })
+      .then(() => utils.getDoc('person'))
+      .then(person => {
+        expect(person.date_of_death).toEqual(doc.reported_date);
+      })
+      .then(() => utils.getDoc('person2'))
+      .then(person2 => {
+        expect(person2.date_of_death).toEqual(undefined);
+      });
+  });
+
+  it('should add date_of_death field to patient with patient_uuid and custom field and not update on second submission', () => {
+    const settings = {
+      transitions: { death_reporting: true },
+      death_reporting: {
+        mark_deceased_forms: ['DEAD'],
+        undo_deceased_forms: ['UNDEAD'],
+        date_field: 'fields.time_of_death'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      form: 'DEAD',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      fields: {
+        patient_id: 'person',
+        time_of_death: 123456789
+      }
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      form: 'DEAD',
+      type: 'data_record',
+      reported_date: new Date().getTime(),
+      fields: {
+        patient_id: 'person',
+        time_of_death: 9876544321
+      }
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.death_reporting).toBeDefined();
+        expect(info.transitions.death_reporting.ok).toEqual(true);
+      })
+      .then(() => utils.getDoc('person'))
+      .then(person => {
+        expect(person.date_of_death).toEqual(doc.fields.time_of_death);
+      })
+      .then(() => utils.saveDoc(doc2))
+      .then(() => sentinelUtils.waitForSentinel(doc2._id))
+      .then(() => sentinelUtils.getInfoDoc(doc2._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc('person'))
+      .then(person => {
+        expect(person.date_of_death).toEqual(doc.fields.time_of_death);
+      })
+  });
+
+});

--- a/tests/e2e/sentinel/transitions/death_reporting.spec.js
+++ b/tests/e2e/sentinel/transitions/death_reporting.spec.js
@@ -47,11 +47,11 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc('person'))
       .then(person => {
-        expect(person.date_of_death).toEqual(undefined);
+        expect(person.date_of_death).not.toBeDefined();
       });
   });
 
@@ -81,11 +81,11 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc('person'))
       .then(person => {
-        expect(person.date_of_death).toEqual(undefined);
+        expect(person.date_of_death).not.toBeDefined();
       });
   });
 
@@ -115,11 +115,11 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc('person'))
       .then(person => {
-        expect(person.date_of_death).toEqual(undefined);
+        expect(person.date_of_death).not.toBeDefined();
       });
   });
 
@@ -159,7 +159,7 @@ describe('death_reporting', () => {
       })
       .then(() => utils.getDoc('person2'))
       .then(person2 => {
-        expect(person2.date_of_death).toEqual(undefined);
+        expect(person2.date_of_death).not.toBeDefined();
       });
   });
 
@@ -223,7 +223,7 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc2._id))
       .then(() => sentinelUtils.getInfoDoc(doc2._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc('person'))
       .then(person => {
@@ -239,7 +239,7 @@ describe('death_reporting', () => {
       })
       .then(() => utils.getDoc('person'))
       .then(person => {
-        expect(person.date_of_death).toEqual(undefined);
+        expect(person.date_of_death).not.toBeDefined();
       });
   });
 

--- a/tests/e2e/sentinel/transitions/default_responses.spec.js
+++ b/tests/e2e/sentinel/transitions/default_responses.spec.js
@@ -64,6 +64,7 @@ describe('default_responses', () => {
         expect(updated.tasks).toBeDefined();
         expect(updated.tasks.length).toEqual(1);
         expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+        expect(updated.tasks[0].state).toEqual('pending');
       });
   });
 
@@ -101,6 +102,7 @@ describe('default_responses', () => {
         expect(updated.tasks).toBeDefined();
         expect(updated.tasks.length).toEqual(1);
         expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+        expect(updated.tasks[0].state).toEqual('pending');
       });
   });
 
@@ -138,6 +140,7 @@ describe('default_responses', () => {
         expect(updated.tasks).toBeDefined();
         expect(updated.tasks.length).toEqual(1);
         expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+        expect(updated.tasks[0].state).toEqual('pending');
       });
   });
 });

--- a/tests/e2e/sentinel/transitions/default_responses.spec.js
+++ b/tests/e2e/sentinel/transitions/default_responses.spec.js
@@ -27,7 +27,7 @@ describe('default_responses', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       });
   });
 

--- a/tests/e2e/sentinel/transitions/default_responses.spec.js
+++ b/tests/e2e/sentinel/transitions/default_responses.spec.js
@@ -110,12 +110,15 @@ describe('default_responses', () => {
       default_responses: {
         start_date: '2018-01-01'
       },
-      forms_only_mode: true
+      forms_only_mode: false
     };
 
     const doc = {
       _id: uuid(),
       type: 'data_record',
+      errors: [{
+        code: 'sys.form_not_found'
+      }],
       from: '1234567890',
       reported_date: new Date().getTime()
     };

--- a/tests/e2e/sentinel/transitions/default_responses.spec.js
+++ b/tests/e2e/sentinel/transitions/default_responses.spec.js
@@ -1,0 +1,140 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('default_responses', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { default_responses: false }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '1234567890',
+      errors: [{
+        code: 'sys.empty'
+      }],
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      });
+  });
+
+  it('should add default response when message is empty', () => {
+    const settings = {
+      transitions: { default_responses: true },
+      default_responses: {
+        start_date: '2018-01-01'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '1234567890',
+      errors: [{
+        code: 'sys.empty'
+      }],
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.default_responses).toBeDefined();
+        expect(info.transitions.default_responses.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+      });
+  });
+
+  it('should add default response when form not found', () => {
+    const settings = {
+      transitions: { default_responses: true },
+      default_responses: {
+        start_date: '2018-01-01'
+      },
+      forms_only_mode: true
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '1234567890',
+      errors: [{
+        code: 'sys.form_not_found'
+      }],
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.default_responses).toBeDefined();
+        expect(info.transitions.default_responses.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+      });
+  });
+
+  it('should add default response when form is found', () => {
+    const settings = {
+      transitions: { default_responses: true },
+      default_responses: {
+        start_date: '2018-01-01'
+      },
+      forms_only_mode: true
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '1234567890',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.default_responses).toBeDefined();
+        expect(info.transitions.default_responses.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].to).toEqual(doc.from);
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
@@ -23,11 +23,11 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc(doc._id))
       .then(person => {
-        expect(person.patient_id).toEqual(undefined);
+        expect(person.patient_id).not.toBeDefined();
       });
   });
 
@@ -48,11 +48,11 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc(doc._id))
       .then(person => {
-        expect(person.patient_id).toEqual(undefined);
+        expect(person.patient_id).not.toBeDefined();
       });
   });
 
@@ -74,7 +74,7 @@ describe('death_reporting', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       })
       .then(() => utils.getDoc(doc._id))
       .then(person => {
@@ -105,7 +105,7 @@ describe('death_reporting', () => {
       })
       .then(() => utils.getDoc(doc._id))
       .then(person => {
-        expect(person.patient_id).not.toEqual(undefined);
+        expect(person.patient_id).toBeDefined();
       });
   });
 });

--- a/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
@@ -1,0 +1,111 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('death_reporting', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { generate_patient_id_on_people: false }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'person',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.patient_id).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when not a person', () => {
+    const settings = {
+      transitions: { generate_patient_id_on_people: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'clinic',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.patient_id).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when patient_id is filled', () => {
+    const settings = {
+      transitions: { generate_patient_id_on_people: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'person',
+      patient_id: '1234',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.patient_id).toEqual('1234');
+      });
+  });
+
+  it('should add patient_id', () => {
+    const settings = {
+      transitions: { generate_patient_id_on_people: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'person',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.generate_patient_id_on_people).toBeDefined();
+        expect(info.transitions.generate_patient_id_on_people.ok).toEqual(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.patient_id).not.toEqual(undefined);
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
@@ -169,13 +169,13 @@ describe('multi_report_alerts', () => {
         expect(updated.tasks[0].messages[0].to).toEqual('987654321');
         expect(updated.tasks[0].state).toEqual('pending');
 
-        expect(updated.tasks[0].messages[0].message).toEqual('multi_report_message');
+        expect(updated.tasks[1].messages[0].message).toEqual('multi_report_message');
         // this is a bug https://github.com/medic/medic/issues/5369
-        expect(updated.tasks[0].messages[0].to).toEqual('987654321');
-        expect(updated.tasks[0].state).toEqual('duplicate');
+        expect(updated.tasks[1].messages[0].to).toEqual('987654321');
+        expect(updated.tasks[1].state).toEqual('duplicate');
         // these should be the correct values!
-        //expect(updated.tasks[0].messages[0].to).toEqual('0123456789');
-        //expect(updated.tasks[0].state).toEqual('pending');
+        //expect(updated.tasks[1].messages[0].to).toEqual('0123456789');
+        //expect(updated.tasks[1].state).toEqual('pending');
 
       });
   });
@@ -279,7 +279,6 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
       .updateSettings(settings, true)
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))

--- a/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
@@ -1,0 +1,305 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('multi_report_alerts', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { multi_report_alerts: false },
+      multi_report_alerts: [{
+        name: 'test',
+        is_report_counted: 'function(r, l) { return true }',
+        num_reports_threshold: 1,
+        message: 'multi_report_message',
+        recipients: 'new_report.from',
+        time_window_in_days: 1,
+        forms: 'FORM'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FROM',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      });
+  });
+
+  it('should be skipped when no matching config', () => {
+    const settings = {
+      transitions: { multi_report_alerts: false },
+      multi_report_alerts: [{
+        name: 'test',
+        is_report_counted: 'function(r, l) { return true }',
+        num_reports_threshold: 1,
+        message: 'multi_report_message',
+        recipients: 'new_report.from',
+        time_window_in_days: 1,
+        forms: 'FORM'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'NOT_FORM',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toEqual(undefined);
+      });
+  });
+
+  it('should add task when matched', () => {
+    const settings = {
+      transitions: { multi_report_alerts: true },
+      multi_report_alerts: [{
+        name: 'test',
+        is_report_counted: 'function(r, l) { return true }',
+        num_reports_threshold: 1,
+        message: 'multi_report_message',
+        recipients: ['new_report.from'],
+        time_window_in_days: 1,
+        forms: 'FORM'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '0123456789',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.multi_report_alerts).toBeDefined();
+        expect(info.transitions.multi_report_alerts.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].message).toEqual('multi_report_message');
+        expect(updated.tasks[0].messages[0].to).toEqual('0123456789');
+        expect(updated.tasks[0].state).toEqual('pending');
+      });
+  });
+
+  it('should not add task when threshold not reached', () => {
+    const settings = {
+      transitions: { multi_report_alerts: true },
+      multi_report_alerts: [{
+        name: 'test',
+        is_report_counted: 'function(r, l) { return true }',
+        num_reports_threshold: 2,
+        message: 'multi_report_message',
+        recipients: ['new_report.from'],
+        time_window_in_days: 1,
+        forms: 'FORM'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '0123456789',
+      reported_date: new Date().getTime() - 100
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '987654321',
+      reported_date: new Date().getTime() + 100
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(doc2))
+      .then(() => sentinelUtils.waitForSentinel(doc2._id))
+      .then(() => sentinelUtils.getInfoDoc(doc2._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.multi_report_alerts).toBeDefined();
+        expect(info.transitions.multi_report_alerts.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc2._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(2);
+
+        expect(updated.tasks[0].messages[0].message).toEqual('multi_report_message');
+        expect(updated.tasks[0].messages[0].to).toEqual('987654321');
+        expect(updated.tasks[0].state).toEqual('pending');
+
+        expect(updated.tasks[0].messages[0].message).toEqual('multi_report_message');
+        // this is a bug https://github.com/medic/medic/issues/5369
+        expect(updated.tasks[0].messages[0].to).toEqual('987654321');
+        expect(updated.tasks[0].state).toEqual('duplicate');
+        // these should be the correct values!
+        //expect(updated.tasks[0].messages[0].to).toEqual('0123456789');
+        //expect(updated.tasks[0].state).toEqual('pending');
+
+      });
+  });
+
+  it('should not add task when conditions not met', () => {
+    const settings = {
+      transitions: { multi_report_alerts: true },
+      multi_report_alerts: [{
+        name: 'test',
+        is_report_counted: 'function(r, l) { return r.magic; }',
+        num_reports_threshold: 1,
+        message: 'multi_report_magic',
+        recipients: ['new_report.sent_by', 'new_report.home_phone'],
+        time_window_in_days: 1,
+        forms: 'FORM'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      sent_by: '0123456789',
+      home_phone: '01010101',
+      reported_date: new Date().getTime() - 100
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      sent_by: '987654321',
+      home_phone: '12121212',
+      magic: true,
+      reported_date: new Date().getTime() + 100
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(doc2))
+      .then(() => sentinelUtils.waitForSentinel(doc2._id))
+      .then(() => sentinelUtils.getInfoDoc(doc2._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.multi_report_alerts).toBeDefined();
+        expect(info.transitions.multi_report_alerts.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc2._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(2);
+
+        expect(updated.tasks[0].messages[0].message).toEqual('multi_report_magic');
+        expect(updated.tasks[0].messages[0].to).toEqual('987654321');
+        expect(updated.tasks[0].state).toEqual('pending');
+
+        expect(updated.tasks[1].messages[0].message).toEqual('multi_report_magic');
+        expect(updated.tasks[1].messages[0].to).toEqual('12121212');
+        expect(updated.tasks[1].state).toEqual('pending');
+      });
+  });
+
+  it('should not count reports that are outside of the time window', () => {
+    const settings = {
+      transitions: { multi_report_alerts: true },
+      multi_report_alerts: [{
+        name: 'test',
+        is_report_counted: 'function(r, l) { return true }',
+        num_reports_threshold: 2,
+        message: 'multi_report_message',
+        recipients: ['new_report.from'],
+        time_window_in_days: 1,
+        forms: 'FORM'
+      }]
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '0123456789',
+      reported_date: new Date().getTime() - 25 * 60 * 60 * 1000
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '987654321',
+      reported_date: new Date().getTime() + 100
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(doc2))
+      .then(() => sentinelUtils.waitForSentinel(doc2._id))
+      .then(() => sentinelUtils.getInfoDoc(doc2._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc2._id))
+      .then(updated => {
+        expect(updated.tasks).not.toBeDefined();
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
@@ -33,7 +33,7 @@ describe('multi_report_alerts', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       });
   });
 
@@ -64,7 +64,7 @@ describe('multi_report_alerts', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toEqual(undefined);
+        expect(info.transitions).not.toBeDefined();
       });
   });
 

--- a/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
@@ -172,7 +172,6 @@ describe('multi_report_alerts', () => {
         expect(updated.tasks[1].messages[0].message).toEqual('multi_report_message');
         expect(updated.tasks[1].messages[0].to).toEqual('+251 11 551 1211');
         expect(updated.tasks[1].state).toEqual('pending');
-
       });
   });
 

--- a/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
@@ -128,7 +128,7 @@ describe('multi_report_alerts', () => {
       _id: uuid(),
       type: 'data_record',
       form: 'FORM',
-      from: '0123456789',
+      from: '+251 11 551 1211',
       reported_date: new Date().getTime() - 100
     };
 
@@ -136,7 +136,7 @@ describe('multi_report_alerts', () => {
       _id: uuid(),
       type: 'data_record',
       form: 'FORM',
-      from: '987654321',
+      from: '+256 41 9867538',
       reported_date: new Date().getTime() + 100
     };
 
@@ -166,16 +166,12 @@ describe('multi_report_alerts', () => {
         expect(updated.tasks.length).toEqual(2);
 
         expect(updated.tasks[0].messages[0].message).toEqual('multi_report_message');
-        expect(updated.tasks[0].messages[0].to).toEqual('987654321');
+        expect(updated.tasks[0].messages[0].to).toEqual('+256 41 9867538');
         expect(updated.tasks[0].state).toEqual('pending');
 
         expect(updated.tasks[1].messages[0].message).toEqual('multi_report_message');
-        // this is a bug https://github.com/medic/medic/issues/5369
-        expect(updated.tasks[1].messages[0].to).toEqual('987654321');
-        expect(updated.tasks[1].state).toEqual('duplicate');
-        // these should be the correct values!
-        //expect(updated.tasks[1].messages[0].to).toEqual('0123456789');
-        //expect(updated.tasks[1].state).toEqual('pending');
+        expect(updated.tasks[1].messages[0].to).toEqual('+251 11 551 1211');
+        expect(updated.tasks[1].state).toEqual('pending');
 
       });
   });

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -853,6 +853,6 @@ describe('muting', () => {
         expect(reports[2].scheduled_tasks[0].state).toEqual('something_else');
         expect(reports[2].scheduled_tasks[1].state).toEqual('scheduled');
         expect(reports[2].scheduled_tasks[2].state).toEqual('muted'); // due date in the past
-      })
+      });
   });
 });

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -1,0 +1,455 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+
+const contacts = [
+  {
+    _id: 'district_hospital',
+    name: 'District hospital',
+    type: 'district_hospital',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'health_center',
+    name: 'Health Center',
+    type: 'health_center',
+    parent: { _id: 'district_hospital' },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person',
+    name: 'Person',
+    type: 'person',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+444999',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic2',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person2', parent:  { _id: 'clinic2', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person2',
+    name: 'Person',
+    type: 'person',
+    parent: { _id: 'clinic2', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+444999',
+    reported_date: new Date().getTime()
+  },
+];
+
+describe('muting', () => {
+  beforeEach(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { muting: false },
+      muting: {
+        mute_forms: ['mute'],
+        unmute_forms: ['unmute']
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'mute',
+      fields: {
+        patient_uuid: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped when no matching config', () => {
+    const settings = {
+      transitions: { muting: true },
+      muting: {
+        mute_forms: ['mute'],
+        unmute_forms: ['unmute']
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'NOT_MUTE',
+      fields: {
+        patient_uuid: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should add error when contact not found', () => {
+    const settings = {
+      transitions: { muting: true },
+      muting: {
+        mute_forms: ['mute'],
+        unmute_forms: ['unmute'],
+        messages: [{
+          event_type: 'contact_not_found',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact not found'
+          }],
+        }]
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'mute',
+      fields: {
+        patient_id: 'unknown'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.muting).toBeDefined();
+        expect(info.transitions.muting.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].message).toEqual('Contact not found');
+        expect(updated.tasks[0].messages[0].to).toEqual('12345');
+        expect(updated.tasks[0].state).toEqual('pending');
+
+        expect(updated.errors).toBeDefined();
+        expect(updated.errors.length).toEqual(1);
+        expect(updated.errors[0].message).toEqual('Contact not found');
+      });
+  });
+
+  it('should mute and unmute a person', () => {
+    const settings = {
+      transitions: { muting: true },
+      muting: {
+        mute_forms: ['mute'],
+        unmute_forms: ['unmute'],
+        messages: [{
+          event_type: 'mute',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact muted'
+          }],
+        }, {
+          event_type: 'unmute',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact unmuted'
+          }],
+        }, {
+          event_type: 'already_muted',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact already muted'
+          }],
+        }, {
+          event_type: 'already_unmuted',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact already unmuted'
+          }],
+        }]
+      }
+    };
+
+    const mute1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'mute',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const mute2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'mute',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const unmute1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'unmute',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const unmute2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'unmute',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    let muteTime,
+        unmuteTime;
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(mute1))
+      .then(() => sentinelUtils.waitForSentinel(mute1._id))
+      .then(() => sentinelUtils.getInfoDocs([mute1._id, 'person']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(1);
+        expect(infos[1].muting_history[0].muted).toEqual(true);
+        expect(infos[1].muting_history[0].report_id).toEqual(mute1._id);
+        muteTime = infos[1].muting_history[0].date;
+      })
+      .then(() => utils.getDocs([mute1._id, 'person', 'person2', 'clinic']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact muted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].muted).toEqual(muteTime);
+
+        expect(updated[2].muted).not.toBeDefined();
+        expect(updated[3].muted).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(mute2))
+      .then(() => sentinelUtils.waitForSentinel(mute2._id))
+      .then(() => sentinelUtils.getInfoDocs([mute2._id, 'person']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(1);
+        expect(infos[1].muting_history[0].date).toEqual(muteTime);
+      })
+      .then(() => utils.getDocs([mute2._id, 'person']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact already muted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].muted).toEqual(muteTime);
+      })
+      .then(() => utils.saveDoc(unmute1))
+      .then(() => sentinelUtils.waitForSentinel(unmute1._id))
+      .then(() => sentinelUtils.getInfoDocs([unmute1._id, 'person']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(2);
+        expect(infos[1].muting_history[1].muted).toEqual(false);
+        expect(infos[1].muting_history[1].report_id).toEqual(unmute1._id);
+        unmuteTime = infos[1].muting_history[1].date;
+      })
+      .then(() => utils.getDocs([unmute1._id, 'person']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact unmuted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].muted).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(unmute2))
+      .then(() => sentinelUtils.waitForSentinel(unmute2._id))
+      .then(() => sentinelUtils.getInfoDocs([unmute2._id, 'person']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(2);
+        expect(infos[1].muting_history[1].date).toEqual(unmuteTime);
+      })
+      .then(() => utils.getDocs([unmute2._id, 'person']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact already unmuted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].muted).not.toBeDefined();
+      })
+  });
+
+  it('should mute and unmute a clinic', () => {
+    const settings = {
+      transitions: { muting: true },
+      muting: {
+        mute_forms: ['mute'],
+        unmute_forms: ['unmute']
+      }
+    };
+
+    const mute = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'mute',
+      fields: {
+        place_id: 'clinic'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const unmute = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'unmute',
+      fields: {
+        place_id: 'clinic'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    let muteTime;
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(mute))
+      .then(() => sentinelUtils.waitForSentinel(mute._id))
+      .then(() => sentinelUtils.getInfoDocs([mute._id, 'clinic', 'person', 'clinic2', 'person2']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(1);
+        expect(infos[1].muting_history[0].muted).toEqual(true);
+        expect(infos[1].muting_history[0].report_id).toEqual(mute._id);
+        muteTime = infos[1].muting_history[0].date;
+
+        expect(infos[2].muting_history).toBeDefined();
+        expect(infos[2].muting_history.length).toEqual(1);
+
+        expect(infos[2].muting_history[0]).toEqual({
+          muted: true,
+          report_id: mute._id,
+          date: muteTime
+        });
+
+        expect(infos[3].muting_history).not.toBeDefined();
+        expect(infos[4].muting_history).not.toBeDefined();
+      })
+      .then(() => utils.getDocs(['clinic', 'person', 'person2', 'clinic2']))
+      .then(updated => {
+        expect(updated[0].muted).toEqual(muteTime);
+        expect(updated[1].muted).toEqual(muteTime);
+
+        expect(updated[2].muted).not.toBeDefined();
+        expect(updated[3].muted).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(unmute))
+      .then(() => sentinelUtils.waitForSentinel(unmute._id))
+      .then(() => sentinelUtils.getInfoDocs([unmute._id, 'clinic', 'person', 'clinic2', 'person2']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(2);
+        expect(infos[1].muting_history[0]).toEqual({
+          muted: true,
+          report_id: mute._id,
+          date: muteTime
+        });
+        expect(infos[1].muting_history[1].muted).toEqual(false);
+        expect(infos[1].muting_history[1].report_id).toEqual(unmute._id);
+
+        expect(infos[2].muting_history).toBeDefined();
+        expect(infos[2].muting_history.length).toEqual(2);
+        expect(infos[2].muting_history[0]).toEqual({
+          muted: true,
+          report_id: mute._id,
+          date: muteTime
+        });
+        expect(infos[2].muting_history[1].muted).toEqual(false);
+        expect(infos[2].muting_history[1].report_id).toEqual(unmute._id);
+
+        expect(infos[3].muting_history).not.toBeDefined();
+        expect(infos[4].muting_history).not.toBeDefined();
+      })
+      .then(() => utils.getDocs(['clinic', 'person', 'person2', 'clinic2']))
+      .then(updated => {
+        expect(updated[0].muted).not.toBeDefined();
+        expect(updated[1].muted).not.toBeDefined();
+        expect(updated[2].muted).not.toBeDefined();
+        expect(updated[3].muted).not.toBeDefined();
+      });
+  });
+
+});

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -151,6 +151,7 @@ describe('muting', () => {
       _id: uuid(),
       type: 'data_record',
       form: 'mute',
+      from: '12345',
       fields: {
         patient_id: 'unknown'
       },
@@ -161,6 +162,7 @@ describe('muting', () => {
       _id: uuid(),
       type: 'data_record',
       form: 'mute',
+      from: '12345',
       fields: {
         patient_id: 'this will not pass validation'
       },
@@ -196,8 +198,7 @@ describe('muting', () => {
         expect(updated[1].tasks).toBeDefined();
         expect(updated[1].tasks.length).toEqual(1);
         expect(updated[1].tasks[0].messages[0].message).toEqual('Patient id incorrect');
-        // possible bug/feature(?) - validation messages are always sent to `clinic`
-        expect(updated[1].tasks[0].messages[0].to).toEqual('clinic');
+        expect(updated[1].tasks[0].messages[0].to).toEqual('12345');
         expect(updated[1].tasks[0].state).toEqual('pending');
 
         expect(updated[1].errors).toBeDefined();

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -117,7 +117,7 @@ describe('muting', () => {
       });
   });
 
-  it('should add error when contact not found', () => {
+  it('should add error when contact not found, should add error when invalid', () => {
     const settings = {
       transitions: { muting: true },
       muting: {
@@ -130,11 +130,24 @@ describe('muting', () => {
             locale: 'en',
             content: 'Contact not found'
           }],
-        }]
+        }],
+        validations: {
+          list: [
+            {
+              property: 'patient_id',
+              rule: 'lenMin(5) && lenMax(10)',
+              message: [{
+                locale: 'en',
+                content: 'Patient id incorrect'
+              }],
+            },
+          ],
+          join_responses: false
+        }
       }
     };
 
-    const doc = {
+    const doc1 = {
       _id: uuid(),
       type: 'data_record',
       form: 'mute',
@@ -144,27 +157,52 @@ describe('muting', () => {
       reported_date: new Date().getTime()
     };
 
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'mute',
+      fields: {
+        patient_id: 'this will not pass validation'
+      },
+      reported_date: new Date().getTime()
+    };
+
     return utils
       .updateSettings(settings, true)
-      .then(() => utils.saveDoc(doc))
-      .then(() => sentinelUtils.waitForSentinel(doc._id))
-      .then(() => sentinelUtils.getInfoDoc(doc._id))
-      .then(info => {
-        expect(info.transitions).toBeDefined();
-        expect(info.transitions.muting).toBeDefined();
-        expect(info.transitions.muting.ok).toBe(true);
-      })
-      .then(() => utils.getDoc(doc._id))
-      .then(updated => {
-        expect(updated.tasks).toBeDefined();
-        expect(updated.tasks.length).toEqual(1);
-        expect(updated.tasks[0].messages[0].message).toEqual('Contact not found');
-        expect(updated.tasks[0].messages[0].to).toEqual('12345');
-        expect(updated.tasks[0].state).toEqual('pending');
+      .then(() => utils.saveDocs([doc1, doc2]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.muting).toBeDefined();
+        expect(infos[0].transitions.muting.ok).toBe(true);
 
-        expect(updated.errors).toBeDefined();
-        expect(updated.errors.length).toEqual(1);
-        expect(updated.errors[0].message).toEqual('Contact not found');
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.muting).toBeDefined();
+        expect(infos[1].transitions.muting.ok).toBe(true);
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact not found');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+        expect(updated[0].tasks[0].state).toEqual('pending');
+
+        expect(updated[0].errors).toBeDefined();
+        expect(updated[0].errors.length).toEqual(1);
+        expect(updated[0].errors[0].message).toEqual('Contact not found');
+
+        expect(updated[1].tasks).toBeDefined();
+        expect(updated[1].tasks.length).toEqual(1);
+        expect(updated[1].tasks[0].messages[0].message).toEqual('Patient id incorrect');
+        // possible bug/feature(?) - validation messages are always sent to `clinic`
+        expect(updated[1].tasks[0].messages[0].to).toEqual('clinic');
+        expect(updated[1].tasks[0].state).toEqual('pending');
+
+        expect(updated[1].errors).toBeDefined();
+        expect(updated[1].errors.length).toEqual(1);
+        expect(updated[1].errors[0].message).toEqual('Patient id incorrect');
       });
   });
 

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -37,9 +37,9 @@ const contacts = [
 ];
 
 describe('registration', () => {
-  beforeEach(done => utils.saveDocs(contacts).then(done));
+  beforeAll(done => utils.saveDocs(contacts).then(done));
   afterAll(done => utils.revertDb().then(done));
-  afterEach(done => utils.revertDb([], true).then(done));
+  afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
 
   it('should be skipped when transition is disabled', () => {
     const settings = {

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -1,0 +1,349 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid'),
+      moment = require('moment');
+
+const contacts = [
+  {
+    _id: 'district_hospital',
+    name: 'District hospital',
+    type: 'district_hospital',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'health_center',
+    name: 'Health Center',
+    type: 'health_center',
+    parent: { _id: 'district_hospital' },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person',
+    name: 'Person',
+    type: 'person',
+    patient_id: 'patient',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+444999',
+    reported_date: new Date().getTime()
+  }
+];
+
+describe('registration', () => {
+  beforeEach(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { registration: false },
+      registrations: [{
+        form: 'FORM',
+        events: [],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          message: [{
+            locale: 'en',
+            content: 'Report accepted'
+          }],
+        }]
+      }],
+      forms: { FORM: { public_form: true }}
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      reported_date: moment().valueOf()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped if no config', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM',
+        events: [],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          message: [{
+            locale: 'en',
+            content: 'Report accepted'
+          }],
+        }]
+      }],
+      forms: { FORM: { public_form: true }}
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'NOT_FORM',
+      reported_date: moment().valueOf()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).not.toBeDefined();
+      })
+  });
+
+  it('should error if invalid or if patient not found', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM',
+        events: [],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          message: [{
+            locale: 'en',
+            content: 'Report accepted'
+          }],
+        }, {
+          event_type: 'registration_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Patient not found'
+          }],
+        }],
+        validations: {
+          list: [{
+            property: 'count',
+            rule: 'min(10)',
+            message: [{
+              locale: 'en',
+              content: 'Count is incorrect'
+            }],
+          }]
+        }
+      }],
+      forms: { FORM: { public_form: true }}
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '12345',
+      form: 'FORM',
+      fields: {
+        count: 3
+      },
+      reported_date: moment().valueOf()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '12345',
+      fields: {
+        patient_id: 'non_existent',
+        count: 22
+      },
+      reported_date: moment().valueOf()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([ doc1, doc2 ]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.registration).toBeDefined();
+        expect(infos[0].transitions.registration.ok).toEqual(true);
+
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.registration).toBeDefined();
+        expect(infos[1].transitions.registration.ok).toEqual(true);
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Count is incorrect');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+
+        expect(updated[0].errors).toBeDefined();
+        expect(updated[0].errors.length).toEqual(1);
+        expect(updated[0].errors[0].message).toEqual('Count is incorrect');
+
+        expect(updated[1].tasks).toBeDefined();
+        expect(updated[1].tasks.length).toEqual(1);
+        expect(updated[1].tasks[0].messages[0].message).toEqual('Patient not found');
+        expect(updated[1].tasks[0].messages[0].to).toEqual('12345');
+
+        expect(updated[1].errors).toBeDefined();
+        expect(updated[1].errors.length).toEqual(1);
+        expect(updated[1].errors[0].code).toEqual('registration_not_found');
+      });
+  });
+
+  it('should create a patient with a random patient_id', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: '',
+          bool_expr: ''
+        }],
+        messages: [],
+      }],
+      forms: { FORM: { public_form: true }}
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '+444999',
+      fields: {
+        patient_name: 'Minerva',
+      },
+      reported_date: moment().valueOf()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '+444999',
+      fields: {
+        patient_id: 'person',
+        patient_name: 'Mike',
+      },
+      reported_date: moment().valueOf()
+    };
+
+    let newPatientId;
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([ doc1, doc2 ]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.registration).toBeDefined();
+        expect(infos[0].transitions.registration.ok).toEqual(true);
+
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.registration).toBeDefined();
+        expect(infos[1].transitions.registration.ok).toEqual(true);
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        expect(updated[0].patient_id).toBeDefined();
+        newPatientId = updated[0].patient_id;
+        expect(updated[1].patient_id).not.toBeDefined();
+        expect(updated[1].fields.patient_id).toEqual('person');
+
+        return utils.requestOnTestDb(
+          `/_design/medic-client/_view/contacts_by_reference?key=["shortcode","${updated[0].patient_id}"]&include_docs=true`
+        );
+      })
+      .then(response => {
+        expect(response.rows.length).toEqual(1);
+        expect(response.rows[0].doc.patient_id).toEqual(newPatientId);
+        expect(response.rows[0].doc.parent._id).toEqual('clinic');
+        expect(response.rows[0].doc.name).toEqual('Minerva');
+      });
+  });
+
+  it('should add expected date', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_expected_date',
+          params: '',
+          bool_expr: ''
+        }],
+        messages: [],
+      }],
+      forms: { FORM: { public_form: true }}
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '+444999',
+      fields: {
+        patient_id: 'patient',
+        weeks_since_lmp: 2,
+      },
+      reported_date: moment().valueOf()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM',
+      from: '+444999',
+      fields: {
+        patient_id: 'patient',
+        last_menstrual_period: 2
+      },
+      reported_date: moment().subtract('2 weeks').valueOf()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([ doc1, doc2 ]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.registration).toBeDefined();
+        expect(infos[0].transitions.registration.ok).toEqual(true);
+
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.registration).toBeDefined();
+        expect(infos[1].transitions.registration.ok).toEqual(true);
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        console.log(require('util').inspect(updated, { depth: 100 }));
+        expect(updated[0].lmp_date).toBeDefined();
+        expect(updated[0].lmp_date).toEqual(moment().startOf('day').subtract('2 weeks').toISOString());
+
+
+        expect(updated[1].patient_id).not.toBeDefined();
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -402,16 +402,13 @@ describe('registration', () => {
       })
       .then(() => utils.getDocs([doc1._id, doc2._id]))
       .then(updated => {
-        const lmpDate = moment().utc(false).startOf('day').subtract(2, 'weeks').toISOString();
-        const expectedDate = moment().utc(false).startOf('day').add(38, 'weeks').toISOString();
-
         expect(updated[0].lmp_date).toBeDefined();
-        expect(updated[0].lmp_date).toEqual(lmpDate);
-        expect(updated[0].expected_date).toEqual(expectedDate);
-        // even if the doc was "reported" 2 weeks ago, the LMP is calculated relative to current date
+        expect(updated[0].lmp_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'weeks').toISOString());
+        expect(updated[0].expected_date).toEqual(moment().utc(false).startOf('day').add(38, 'weeks').toISOString());
+
         expect(updated[1].lmp_date).toBeDefined();
-        expect(updated[1].lmp_date).toEqual(lmpDate);
-        expect(updated[1].expected_date).toEqual(expectedDate);
+        expect(updated[1].lmp_date).toEqual(moment().utc(false).startOf('day').subtract(4, 'weeks').toISOString());
+        expect(updated[1].expected_date).toEqual(moment().utc(false).startOf('day').add(36, 'weeks').toISOString());
       });
   });
 
@@ -488,9 +485,7 @@ describe('registration', () => {
       .then(() => utils.getDocs([doc1._id, doc2._id, doc3._id]))
       .then(updated => {
         expect(updated[0].birth_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'months').toISOString());
-        // report submitted 2 weeks ago, but dob is calculated relative to current date
-        // bug reported as https://github.com/medic/medic/issues/5410
-        expect(updated[1].birth_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'weeks').toISOString());
+        expect(updated[1].birth_date).toEqual(moment().utc(false).startOf('day').subtract(4, 'weeks').toISOString());
         expect(updated[2].birth_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'years').toISOString());
       });
   });

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -112,7 +112,7 @@ describe('registration', () => {
       .then(() => utils.getDoc(doc._id))
       .then(updated => {
         expect(updated.tasks).not.toBeDefined();
-      })
+      });
   });
 
   it('should error if invalid or if patient not found', () => {
@@ -588,7 +588,7 @@ describe('registration', () => {
         expect(updated[1].scheduled_tasks[2].group).toEqual(1);
         expect(updated[1].scheduled_tasks[2].state).toEqual('scheduled');
         expect(updated[1].scheduled_tasks[2].messages[0].message).toEqual('message4');
-      })
+      });
   });
 
   it('should add messages', () => {

--- a/tests/e2e/sentinel/transitions/resolve_pending.spec.js
+++ b/tests/e2e/sentinel/transitions/resolve_pending.spec.js
@@ -1,0 +1,134 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('resolve_pending', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = { transitions: { resolve_pending: false } };
+
+    const doc = {
+      _id: uuid(),
+      reported_date: new Date().getTime(),
+      tasks: [{
+        state: 'pending'
+      }]
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped when no pending tasks', () => {
+    const settings = { transitions: { resolve_pending: false } };
+
+    const doc = {
+      _id: uuid(),
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should add task when matched', () => {
+    const settings = { transitions: { resolve_pending: true } };
+
+    const doc = {
+      _id: uuid(),
+      reported_date: new Date().getTime(),
+      tasks: [
+        {
+          name: 'task1',
+          state: 'pending',
+          timestamp: new Date().getTime(),
+          state_history: [{
+            state: 'pending',
+            timestamp: new Date().getTime()
+          }],
+          messages: [{ to: 'a', message: 'b' }]
+        },
+        {
+          name: 'task2',
+          state: 'pending',
+          timestamp: new Date().getTime(),
+          state_history: [{
+            state: 'pending',
+            timestamp: new Date().getTime()
+          }],
+          messages: [{ to: 'a', message: 'b' }]
+        }
+      ],
+      scheduled_tasks: [
+        {
+          name: 'task3',
+          state: 'pending',
+          timestamp: new Date().getTime(),
+          state_history: [{
+            state: 'pending',
+            timestamp: new Date().getTime()
+          }],
+          messages: [{ to: 'a', message: 'b' }]
+        },
+        {
+          name: 'task4',
+          state: 'random',
+          timestamp: new Date().getTime(),
+          state_history: [{
+            state: 'pending',
+            timestamp: new Date().getTime()
+          }],
+          messages: [{ to: 'a', message: 'b' }]
+        },
+      ]
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.resolve_pending).toBeDefined();
+        expect(info.transitions.resolve_pending.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks.length).toEqual(2);
+        expect(updated.tasks[0].state).toEqual('sent');
+        expect(updated.tasks[0].state_history.length).toEqual(2);
+        expect(updated.tasks[0].state_history[0].state).toEqual('pending');
+        expect(updated.tasks[0].state_history[1].state).toEqual('sent');
+
+        expect(updated.tasks[1].state).toEqual('sent');
+        expect(updated.tasks[1].state_history.length).toEqual(2);
+        expect(updated.tasks[1].state_history[0].state).toEqual('pending');
+        expect(updated.tasks[1].state_history[1].state).toEqual('sent');
+
+        expect(updated.scheduled_tasks.length).toEqual(2);
+        expect(updated.scheduled_tasks[0].state).toEqual('sent');
+        expect(updated.scheduled_tasks[0].state_history.length).toEqual(2);
+        expect(updated.scheduled_tasks[0].state_history[0].state).toEqual('pending');
+        expect(updated.scheduled_tasks[0].state_history[1].state).toEqual('sent');
+
+        expect(updated.scheduled_tasks[1].state).toEqual('random');
+        expect(updated.scheduled_tasks[1].state_history.length).toEqual(1);
+        expect(updated.scheduled_tasks[1].state_history[0].state).toEqual('pending');
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/update_clinics.spec.js
+++ b/tests/e2e/sentinel/transitions/update_clinics.spec.js
@@ -1,0 +1,188 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('resolve_pending', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {transitions: {update_clinics: false}};
+
+    const contact = {
+      _id: 'contact',
+      type: 'person',
+      phone: '12345',
+      reported_date: new Date().getTime(),
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '12345',
+      reported_date: new Date().getTime(),
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(contact))
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.contact).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped when not matching or has contact', () => {
+    const settings = { transitions: { update_clinics: true } };
+
+    const contact = {
+      _id: 'contact',
+      type: 'person',
+      phone: '12345',
+      reported_date: new Date().getTime(),
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      from: '12345',
+      reported_date: new Date().getTime(),
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      contact: { _id: 'some_other_contact' },
+      from: '12345',
+      reported_date: new Date().getTime(),
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(contact))
+      .then(() => utils.saveDoc(doc1))
+      .then(() => sentinelUtils.waitForSentinel(doc1._id))
+      .then(() => sentinelUtils.getInfoDoc(doc1._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc1._id))
+      .then(updated => {
+        expect(updated.contact).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(doc2))
+      .then(() => sentinelUtils.waitForSentinel(doc2._id))
+      .then(() => sentinelUtils.getInfoDoc(doc2._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDoc(doc2._id))
+      .then(updated => {
+        expect(updated.contact).toEqual({ _id: 'some_other_contact' });
+      });
+  });
+
+  it('should skip when contact not found', () => {
+    const settings = { transitions: { update_clinics: true } };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '12345',
+      reported_date: new Date().getTime()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      refid: 'external',
+      reported_date: new Date().getTime(),
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([doc1, doc2]))
+      .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
+      .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
+      .then(infos => {
+        expect(infos[0].transitions).not.toBeDefined();
+        expect(infos[1].transitions).not.toBeDefined();
+      })
+      .then(() => utils.getDocs([doc1._id, doc2._id]))
+      .then(updated => {
+        expect(updated[0].contact).not.toBeDefined();
+        expect(updated[1].contact).not.toBeDefined();
+      });
+  });
+
+  it('should add contact', () => {
+    const settings = {transitions: {update_clinics: true}};
+    const contacts = [
+      {
+        _id: 'person',
+        type: 'person',
+        rc_code: 'sms_person',
+        reported_date: new Date().getTime(),
+      },
+      {
+        _id: 'clinic',
+        type: 'clinic',
+        rc_code: 'sms_clinic',
+        contact: { _id: 'person' },
+        reported_date: new Date().getTime(),
+      },
+      {
+        _id: 'person2',
+        type: 'person',
+        phone: '21112222',
+        reported_date: new Date().getTime(),
+      }
+    ];
+
+    const refidPerson = {
+      _id: uuid(),
+      type: 'data_record',
+      //refid: 'sms_person',
+      refid: 'SMS_PERSON', // view indexes with uppercase only
+      reported_date: new Date().getTime()
+    };
+
+    const refidClinic = {
+      _id: uuid(),
+      type: 'data_record',
+      //refid: 'sms_clinic',
+      refid: 'SMS_CLINIC', // view indexes with uppercase only
+      reported_date: new Date().getTime()
+    };
+
+    const phonePerson = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '21112222',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs(contacts))
+      .then(() => utils.saveDocs([ refidClinic, refidPerson, phonePerson ]))
+      .then(() => sentinelUtils.waitForSentinel([refidClinic._id, refidPerson._id, phonePerson._id]))
+      .then(() => sentinelUtils.getInfoDocs([refidClinic._id, refidPerson._id, phonePerson._id]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.update_clinics).toBeDefined();
+        expect(infos[0].transitions.update_clinics.ok).toEqual(true);
+      })
+      .then(() => utils.getDocs([refidClinic._id, refidPerson._id, phonePerson._id]))
+      .then(updated => {
+        expect(updated[0].contact).toEqual({ _id: 'person' });
+        expect(updated[1].contact).toEqual({ _id: 'person' });
+        expect(updated[2].contact).toEqual({ _id: 'person2' });
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/update_clinics.spec.js
+++ b/tests/e2e/sentinel/transitions/update_clinics.spec.js
@@ -147,7 +147,6 @@ describe('resolve_pending', () => {
     const refidPerson = {
       _id: uuid(),
       type: 'data_record',
-      //refid: 'sms_person',
       refid: 'SMS_PERSON', // view indexes with uppercase only
       reported_date: new Date().getTime()
     };
@@ -155,7 +154,6 @@ describe('resolve_pending', () => {
     const refidClinic = {
       _id: uuid(),
       type: 'data_record',
-      //refid: 'sms_clinic',
       refid: 'SMS_CLINIC', // view indexes with uppercase only
       reported_date: new Date().getTime()
     };

--- a/tests/e2e/sentinel/transitions/update_notifications.spec.js
+++ b/tests/e2e/sentinel/transitions/update_notifications.spec.js
@@ -1,0 +1,319 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+const contacts = [
+  {
+    _id: 'district_hospital',
+    name: 'District hospital',
+    type: 'district_hospital',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'health_center',
+    name: 'Health Center',
+    type: 'health_center',
+    parent: { _id: 'district_hospital' },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person',
+    name: 'Person',
+    type: 'person',
+    patient_id: '99999',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+444999',
+    reported_date: new Date().getTime()
+  }
+];
+
+
+describe('update_notifications', () => {
+  beforeEach(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { update_notifications: false },
+      notifications: {
+        on_form: 'on',
+        off_form: 'off'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'off',
+      fields: {
+        patient_uuid: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped when no matching config', () => {
+    const settings = {
+      transitions: { update_notifications: true },
+      notifications: {
+        on_form: 'on',
+        off_form: 'off'
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'not_off',
+      fields: {
+        patient_uuid: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should add error when contact not found', () => {
+    const settings = {
+      transitions: { update_notifications: true },
+      notifications: {
+        on_form: 'on',
+        off_form: 'off',
+        messages: [{
+          event_type: 'patient_not_found',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Patient not found'
+          }],
+        }]
+      }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'off',
+      fields: {
+        patient_id: 'unknown'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.update_notifications).toBeDefined();
+        expect(info.transitions.update_notifications.ok).toBe(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(updated => {
+        expect(updated.tasks).toBeDefined();
+        expect(updated.tasks.length).toEqual(1);
+        expect(updated.tasks[0].messages[0].message).toEqual('Patient not found');
+        expect(updated.tasks[0].messages[0].to).toEqual('12345');
+        expect(updated.tasks[0].state).toEqual('pending');
+
+        expect(updated.errors).toBeDefined();
+        expect(updated.errors.length).toEqual(1);
+        expect(updated.errors[0].message).toEqual('Patient not found');
+      });
+  });
+
+  it('should mute and unmute a person', () => {
+    const settings = {
+      transitions: { update_notifications: true },
+      notifications: {
+        on_form: 'on',
+        off_form: 'off',
+        messages: [{
+          event_type: 'on_mute',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact muted'
+          }],
+        }, {
+          event_type: 'on_unmute',
+          recipient: '12345',
+          message: [{
+            locale: 'en',
+            content: 'Contact unmuted'
+          }],
+        }],
+      }
+    };
+
+    const mute1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'off',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const mute2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'off',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const unmute1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'on',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    const unmute2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'on',
+      fields: {
+        patient_id: 'person'
+      },
+      reported_date: new Date().getTime()
+    };
+
+    let muteTime,
+        unmuteTime;
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(mute1))
+      .then(() => sentinelUtils.waitForSentinel(mute1._id))
+      .then(() => sentinelUtils.getInfoDocs([mute1._id, 'person', 'clinic']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.update_notifications).toBeDefined();
+        expect(infos[0].transitions.update_notifications.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(1);
+        expect(infos[1].muting_history[0].muted).toEqual(true);
+        expect(infos[1].muting_history[0].report_id).toEqual(mute1._id);
+        muteTime = infos[1].muting_history[0].date;
+
+        expect(infos[2].muting_history).not.toBeDefined();
+      })
+      .then(() => utils.getDocs([mute1._id, 'person', 'clinic']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact muted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+
+        expect(updated[1].muted).toEqual(muteTime);
+
+        expect(updated[2].muted).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(mute2))
+      .then(() => sentinelUtils.waitForSentinel(mute2._id))
+      .then(() => sentinelUtils.getInfoDocs([mute2._id, 'person', 'clinic']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.update_notifications).toBeDefined();
+        expect(infos[0].transitions.update_notifications.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(1);
+        expect(infos[1].muting_history[0].date).toEqual(muteTime);
+
+        expect(infos[2].muting_history).not.toBeDefined();
+      })
+      .then(() => utils.getDocs([mute2._id, 'person', 'clinic']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact muted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+
+        expect(updated[1].muted).toEqual(muteTime);
+
+        expect(updated[2].muted).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(unmute1))
+      .then(() => sentinelUtils.waitForSentinel(unmute1._id))
+      .then(() => sentinelUtils.getInfoDocs([unmute1._id, 'person']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.update_notifications).toBeDefined();
+        expect(infos[0].transitions.update_notifications.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(2);
+        expect(infos[1].muting_history[1].muted).toEqual(false);
+        expect(infos[1].muting_history[1].report_id).toEqual(unmute1._id);
+        unmuteTime = infos[1].muting_history[1].date;
+      })
+      .then(() => utils.getDocs([unmute1._id, 'person']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact unmuted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+
+        expect(updated[1].muted).not.toBeDefined();
+      })
+      .then(() => utils.saveDoc(unmute2))
+      .then(() => sentinelUtils.waitForSentinel(unmute2._id))
+      .then(() => sentinelUtils.getInfoDocs([unmute2._id, 'person']))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.update_notifications).toBeDefined();
+        expect(infos[0].transitions.update_notifications.ok).toBe(true);
+
+        expect(infos[1].muting_history).toBeDefined();
+        expect(infos[1].muting_history.length).toEqual(2);
+        expect(infos[1].muting_history[1].date).toEqual(unmuteTime);
+      })
+      .then(() => utils.getDocs([unmute2._id, 'person']))
+      .then(updated => {
+        expect(updated[0].tasks).toBeDefined();
+        expect(updated[0].tasks.length).toEqual(1);
+        expect(updated[0].tasks[0].messages[0].message).toEqual('Contact unmuted');
+        expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
+
+        expect(updated[1].muted).not.toBeDefined();
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/update_notifications.spec.js
+++ b/tests/e2e/sentinel/transitions/update_notifications.spec.js
@@ -171,7 +171,6 @@ describe('update_notifications', () => {
         expect(updated[0].tasks.length).toEqual(1);
         expect(updated[0].tasks[0].messages[0].message).toEqual('Patient not found');
         expect(updated[0].tasks[0].messages[0].to).toEqual('12345');
-        expect(updated[0].tasks[0].state).toEqual('pending');
 
         expect(updated[0].errors).toBeDefined();
         expect(updated[0].errors.length).toEqual(1);
@@ -181,7 +180,6 @@ describe('update_notifications', () => {
         expect(updated[1].tasks.length).toEqual(1);
         expect(updated[1].tasks[0].messages[0].message).toEqual('Patient id incorrect');
         expect(updated[1].tasks[0].messages[0].to).toEqual('12345');
-        expect(updated[1].tasks[0].state).toEqual('pending');
 
         expect(updated[1].errors).toBeDefined();
         expect(updated[1].errors.length).toEqual(1);

--- a/tests/e2e/sentinel/transitions/update_notifications.spec.js
+++ b/tests/e2e/sentinel/transitions/update_notifications.spec.js
@@ -133,6 +133,7 @@ describe('update_notifications', () => {
       _id: uuid(),
       type: 'data_record',
       form: 'off',
+      from: '12345',
       fields: {
         patient_id: 'unknown'
       },
@@ -143,6 +144,7 @@ describe('update_notifications', () => {
       _id: uuid(),
       type: 'data_record',
       form: 'off',
+      from: '12345',
       fields: {
         patient_id: 'this will not match the validation rule'
       },
@@ -178,8 +180,7 @@ describe('update_notifications', () => {
         expect(updated[1].tasks).toBeDefined();
         expect(updated[1].tasks.length).toEqual(1);
         expect(updated[1].tasks[0].messages[0].message).toEqual('Patient id incorrect');
-        // possible bug/feature(?) - validation messages are always sent to `clinic`
-        expect(updated[1].tasks[0].messages[0].to).toEqual('clinic');
+        expect(updated[1].tasks[0].messages[0].to).toEqual('12345');
         expect(updated[1].tasks[0].state).toEqual('pending');
 
         expect(updated[1].errors).toBeDefined();

--- a/tests/e2e/sentinel/transitions/update_scheduled_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/update_scheduled_reports.spec.js
@@ -1,0 +1,268 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+const contacts = [
+  {
+    _id: 'district_hospital',
+    name: 'District hospital',
+    type: 'district_hospital',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'health_center',
+    name: 'Health Center',
+    type: 'health_center',
+    parent: { _id: 'district_hospital' },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person',
+    name: 'Person',
+    type: 'person',
+    patient_id: '99999',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+444999',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person2',
+    name: 'Person',
+    type: 'person',
+    patient_id: '101010',
+    parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+99998888',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'supervisor',
+    name: 'Supervisor',
+    type: 'person',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    phone: '+111222',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'clinic2',
+    name: 'Clinic',
+    type: 'clinic',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+    contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'person3',
+    name: 'Person',
+    type: 'person',
+    patient_id: '202020',
+    parent: { _id: 'clinic2', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+    phone: '+202020',
+    reported_date: new Date().getTime()
+  },
+];
+
+describe('update_scheduled_reports', () => {
+  beforeAll(done => utils.saveDocs(contacts).then(done));
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { update_scheduled_reports: false }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month: 2 },
+      contact: { _id: 'person', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be skipped when not matching or no clinic', () => {
+    const settings = {
+      transitions: { update_scheduled_reports: true }
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018 },
+      contact: { _id: 'person', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month_num: 2 },
+      contact: { _id: 'supervisor', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([doc1, doc2]))
+      .then(() => sentinelUtils.waitForSentinel([ doc1._id, doc2._id ]))
+      .then(() => sentinelUtils.getInfoDocs([ doc1._id, doc2._id ]))
+      .then(infos => {
+        expect(infos[0].transitions).not.toBeDefined();
+        expect(infos[1].transitions).not.toBeDefined();
+      });
+  });
+
+  it('should be do nothing when no duplicates', () => {
+    const settings = {
+      transitions: { update_scheduled_reports: true }
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month: 2},
+      contact: { _id: 'person', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month_num: 3 },
+      contact: { _id: 'person2', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc3 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, week: 22 },
+      contact: { _id: 'person', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc4 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, week_number: 43 },
+      contact: { _id: 'person', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([doc1, doc2, doc3, doc4]))
+      .then(() => sentinelUtils.waitForSentinel([ doc1._id, doc2._id, doc3._id, doc4._id ]))
+      .then(() => sentinelUtils.getInfoDocs([ doc1._id, doc2._id, doc3._id, doc4._id ]))
+      .then(infos => {
+        expect(infos[0].transitions).toBeDefined();
+        expect(infos[0].transitions.update_scheduled_reports.ok).toEqual(true);
+        expect(infos[1].transitions).toBeDefined();
+        expect(infos[1].transitions.update_scheduled_reports.ok).toEqual(true);
+        expect(infos[2].transitions).toBeDefined();
+        expect(infos[2].transitions.update_scheduled_reports.ok).toEqual(true);
+        expect(infos[3].transitions).toBeDefined();
+        expect(infos[3].transitions.update_scheduled_reports.ok).toEqual(true);
+      });
+  });
+
+  it('should delete the older duplicate', () => {
+    const settings = {
+      transitions: { update_scheduled_reports: true }
+    };
+
+    const doc1 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month: 2 },
+      contact: { _id: 'person', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc2 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month: 2 },
+      contact: { _id: 'person2', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc3 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month: 2 },
+      contact: { _id: 'supervisor', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc4 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, week_number: 43 },
+      contact: { _id: 'person2', parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    const doc5 = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'form',
+      fields: { year: 2018, month: 2 },
+      contact: { _id: 'person3', parent: { _id: 'clinic2', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([doc1, doc2, doc3, doc4, doc5]))
+      .then(() => sentinelUtils.waitForSentinel([ doc1._id, doc2._id, doc3._id, doc4._id, doc5._id ]))
+      .then(() => sentinelUtils.getInfoDocs([ doc1._id, doc2._id, doc3._id, doc4._id, doc5._id ]))
+      .then(infos => {
+        //only one of the of doc1, doc2 and doc3 should still exist
+        const duplicates = infos.slice(0, 3);
+        expect(duplicates.filter(info => info).length).toEqual(1);
+
+        expect(infos[3].transitions).toBeDefined();
+        expect(infos[3].transitions.update_scheduled_reports.ok).toEqual(true);
+        expect(infos[4].transitions).toBeDefined();
+        expect(infos[4].transitions.update_scheduled_reports.ok).toEqual(true);
+      })
+      .then(() => utils.getDocs([ doc1._id, doc2._id, doc3._id, doc4._id, doc5._id ]))
+      .then(updated => {
+        //only one of the of doc1, doc2 and doc3 should still exist
+        const duplicates = updated.slice(0, 3);
+        expect(duplicates.filter(doc => doc).length).toEqual(1);
+
+        expect(updated[3].type).toEqual('data_record');
+        expect(updated[4].type).toEqual('data_record');
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/update_scheduled_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/update_scheduled_reports.spec.js
@@ -132,7 +132,7 @@ describe('update_scheduled_reports', () => {
       });
   });
 
-  it('should be do nothing when no duplicates', () => {
+  it('should do nothing when no duplicates', () => {
     const settings = {
       transitions: { update_scheduled_reports: true }
     };

--- a/tests/e2e/sentinel/transitions/update_sent_by.spec.js
+++ b/tests/e2e/sentinel/transitions/update_sent_by.spec.js
@@ -1,0 +1,129 @@
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('update_sent_by', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { update_sent_by: false }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '123456',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).not.toBeDefined();
+      });
+  });
+
+  it('should skip transition when not filtered, when sent_by exists or when contact not found or no name', () => {
+    const settings = {
+      transitions: { update_sent_by: true }
+    };
+
+    const report1 = {
+      _id: uuid(),
+      type: 'data_record',
+      reported_date: new Date().getTime()
+    };
+
+    const report2 = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '123456',
+      sent_by: 'Adam',
+      reported_date: new Date().getTime()
+    };
+
+    const report3 = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '999888',
+      reported_date: new Date().getTime()
+    };
+
+    const report4 = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '789456',
+      reported_date: new Date().getTime()
+    };
+
+    const contact = {
+      _id: uuid,
+      phone: '789456',
+      type: 'person',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(contact))
+      .then(() => utils.saveDocs([report1, report2, report3, report4]))
+      .then(() => sentinelUtils.waitForSentinel([report1._id, report2._id, report3._id, report4._id]))
+      .then(() => sentinelUtils.getInfoDocs([report1._id, report2._id, report3._id, report4._id]))
+      .then(infos => {
+        expect(infos[0].transitions).not.toBeDefined();
+        expect(infos[1].transitions).not.toBeDefined();
+        expect(infos[2].transitions).not.toBeDefined();
+        expect(infos[3].transitions).not.toBeDefined();
+      });
+  });
+
+  it('should add sent by', () => {
+    const settings = {
+      transitions: { update_sent_by: true }
+    };
+
+    const report = {
+      _id: uuid(),
+      type: 'data_record',
+      from: '123456789',
+      reported_date: new Date().getTime()
+    };
+
+    const contacts = [
+      {
+        _id: uuid(),
+        type: 'person',
+        name: 'alpha',
+        phone: '123456789',
+        reported_date: new Date().getTime()
+      },
+      {
+        _id: uuid(),
+        type: 'person',
+        name: 'beta',
+        phone: '987654321',
+        reported_date: new Date().getTime()
+      }
+    ];
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs(contacts))
+      .then(() => utils.saveDoc(report))
+      .then(() => sentinelUtils.waitForSentinel(report._id))
+      .then(() => sentinelUtils.getInfoDoc(report._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.update_sent_by.ok).toEqual(true);
+      })
+      .then(() => utils.getDoc(report._id))
+      .then(updated => {
+        expect(updated.sent_by).toEqual('alpha');
+      });
+  });
+});

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -2,14 +2,14 @@ const utils = require('../../utils'),
       querystring = require('querystring'),
       constants = require('../../constants');
 
-const waitForSentinel = docId => {
+const waitForSentinel = docIds => {
   return requestOnSentinelTestDb('/_local/sentinel-meta-data')
     .then(metaData => metaData.processed_seq)
     .then(seq => {
       const changeOpts = {
         since: seq,
         filter: '_doc_ids',
-        doc_ids: JSON.stringify([docId])
+        doc_ids: JSON.stringify(Array.isArray(docIds) ? docIds : [docIds])
       };
       return utils.requestOnTestDb('/_changes?' + querystring.stringify(changeOpts));
     })
@@ -20,7 +20,7 @@ const waitForSentinel = docId => {
       }
 
       return new Promise(resolve => {
-        setTimeout(() => waitForSentinel(docId).then(resolve), 100);
+        setTimeout(() => waitForSentinel(docIds).then(resolve), 100);
       });
     });
 };

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -44,7 +44,8 @@ const getInfoDocs = (docIds = []) => {
     keys: JSON.stringify(docIds.map(id => id + '-info')),
     include_docs: true
   };
-  return requestOnSentinelTestDb('/_all_docs?' + querystring.stringify(opts)).then(response => response.rows);
+  return requestOnSentinelTestDb('/_all_docs?' + querystring.stringify(opts))
+    .then(response => response.rows.map(row => row.doc));
 };
 
 module.exports = {

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -1,0 +1,55 @@
+const utils = require('../../utils'),
+      querystring = require('querystring'),
+      constants = require('../../constants');
+
+const waitForSentinel = docId => {
+  return requestOnSentinelTestDb('/_local/sentinel-meta-data')
+    .then(metaData => metaData.processed_seq)
+    .then(seq => {
+      const changeOpts = {
+        since: seq,
+        filter: '_doc_ids',
+        doc_ids: JSON.stringify([docId])
+      };
+      return utils.requestOnTestDb('/_changes?' + querystring.stringify(changeOpts));
+    })
+    .then(response => {
+      if (response.results && !response.results.length) {
+        // sentinel has caught up and processed our doc
+        return;
+      }
+
+      return new Promise(resolve => {
+        setTimeout(() => waitForSentinel(docId).then(resolve), 100);
+      });
+    });
+};
+
+const requestOnSentinelTestDb = (options) => {
+  if (typeof options === 'string') {
+    options = {
+      path: options,
+    };
+  }
+  options.path = '/' + constants.DB_NAME + '-sentinel' + (options.path || '');
+  return utils.request(options);
+};
+
+const getInfoDoc = docId => {
+  return requestOnSentinelTestDb('/' + docId + '-info');
+};
+
+const getInfoDocs = (docIds = []) => {
+  const opts = {
+    keys: JSON.stringify(docIds.map(id => id + '-info')),
+    include_docs: true
+  };
+  return requestOnSentinelTestDb('/_all_docs?' + querystring.stringify(opts)).then(response => response.rows);
+};
+
+module.exports = {
+  waitForSentinel: waitForSentinel,
+  requestOnSentinelTestDb: requestOnSentinelTestDb,
+  getInfoDoc: getInfoDoc,
+  getInfoDocs: getInfoDocs
+};

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -2,6 +2,11 @@ const utils = require('../../utils'),
       querystring = require('querystring'),
       constants = require('../../constants');
 
+// This function resolves after Sentinel has processed required all docs (matched by provided docIds).
+// We achieve this by getting the last seq that sentinel has processed, querying the main db's changes feed,
+// filtering by the provided ids and using Sentinel's processed_seq as a since param - simulating what Sentinel's
+// queue would be like. If we receive no results, we are finished. If we receive results, we try again in 100ms.
+// We use the timeout because local docs don't appear on the changes feed, otherwise we could `longpoll` it instead.
 const waitForSentinel = docIds => {
   return requestOnSentinelTestDb('/_local/sentinel-meta-data')
     .then(metaData => metaData.processed_seq)

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -345,6 +345,16 @@ module.exports = {
     return request(options, { debug: debug, notJson: notJson });
   },
 
+  requestOnSentinelTestDb: (options) => {
+    if (typeof options === 'string') {
+      options = {
+        path: options,
+      };
+    }
+    options.path = '/' + constants.DB_NAME + '-sentinel' + (options.path || '');
+    return request(options);
+  },
+
   saveDoc: doc => {
     const postData = JSON.stringify(doc);
     return module.exports.requestOnTestDb({

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -381,6 +381,17 @@ module.exports = {
     });
   },
 
+  getDocs: ids => {
+    return module.exports
+      .requestOnTestDb({
+        path: `/_all_docs?include_docs=true`,
+        method: 'POST',
+        body: { keys: ids || []},
+        headers: { 'content-type': 'application/json' },
+      })
+      .then(response => response.rows.map(row => row.doc));
+  },
+
   deleteDoc: id => {
     return module.exports.getDoc(id).then(doc => {
       doc._deleted = true;

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -345,16 +345,6 @@ module.exports = {
     return request(options, { debug: debug, notJson: notJson });
   },
 
-  requestOnSentinelTestDb: (options) => {
-    if (typeof options === 'string') {
-      options = {
-        path: options,
-      };
-    }
-    options.path = '/' + constants.DB_NAME + '-sentinel' + (options.path || '');
-    return request(options);
-  },
-
   saveDoc: doc => {
     const postData = JSON.stringify(doc);
     return module.exports.requestOnTestDb({


### PR DESCRIPTION
# Description

Adds e2e tests for every Sentinel transition - except for `update_sent_forms` which is only used by the broken `reminders`.

medic/medic#4857

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
