### PR TITLE
Fix linking logic to prevent conflicts

### DIFF
--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -108,7 +108,7 @@ const _silenceReminders = (registration, report, config, callback) => {
       return callback(err);
     }
     
-    registration._rev = response._rev;
+    registration._rev = response.rev;
     callback();
   });
 };

--- a/sentinel/src/transitions/accept_patient_reports.js
+++ b/sentinel/src/transitions/accept_patient_reports.js
@@ -70,16 +70,14 @@ const findToClear = (registration, reported_date, config) => {
     silenceUntil.add(date.getDuration(config.silence_for));
 
     const allTasksBeforeSilenceUntil = tasksUnderReview.filter(
-      task => moment(task.due) <= silenceUntil
+      task => moment(task.due) <= silenceUntil && statesToClear.includes(task.state)
     );
     const groupTypeCombosToClear = uniqueGroupTypeCombos(
       allTasksBeforeSilenceUntil
     );
 
-    return tasksUnderReview.filter(({ group, type, state }) =>
-      hasGroupAndType(groupTypeCombosToClear, [group, type]) &&
-      // only clear tasks that are in a clearable state!
-      statesToClear.includes(state)
+    return tasksUnderReview.filter(({ group, type }) =>
+      hasGroupAndType(groupTypeCombosToClear, [group, type])
     );
   }
 };
@@ -175,10 +173,27 @@ const findValidRegistration = (doc, config, registrations) => {
 const addReportUUIDToRegistration = (doc, config, registrations, callback) => {
     const validRegistration = registrations.length && findValidRegistration(doc, config, registrations);
     if (validRegistration) {
-      return db.medic.put(validRegistration, callback);
+      return db.medic.put(validRegistration, (err) => {
+              if (err) {
+                if (err.name === 'conflict') {
+                  db.get(validRegistration._id, function(err, doc) {
+                    if (err) { 
+                      callback(err);
+                    }
+                    
+                    validRegistration._rev = doc._rev;
+                    db.medic.put(validRegistration, callback);
+                  });
+                } else {
+                  callback(err);
+                }
+              }
+
+              callback(null, true);
+            });
     }
 
-    callback();
+    callback(null, true);
 };
 
 const silenceRegistrations = (config, doc, registrations, callback) => {
@@ -235,12 +250,12 @@ const handleReport = (doc, config, callback) => {
     .then(registrations => {
       addMessagesToDoc(doc, config, registrations);
       addRegistrationToDoc(doc, registrations);
-      addReportUUIDToRegistration(doc, config, registrations, err => {
+      module.exports.silenceRegistrations(config, doc, registrations, err => {
         if (err) {
           return callback(err);
         }
 
-        module.exports.silenceRegistrations(config, doc, registrations, callback);
+        addReportUUIDToRegistration(doc, config, registrations, callback);
       });
     })
     .catch(callback);

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -200,7 +200,7 @@ describe('accept_patient_reports', () => {
     // Helpful diagram for the next 5 tests:
     // https://github.com/medic/medic/issues/4694#issuecomment-459460521
     it('does not associate visit to anything since no reminder messages have been sent yet', done => {
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -259,8 +259,7 @@ describe('accept_patient_reports', () => {
     });
 
     it('does not associate visit to anything since it is not responding to a reminder', done => {
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j' });
-      sinon.stub(db.medic, 'get').callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -320,8 +319,8 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 1', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
+      putRegistration.callsArgWith(1, null, { ok : true, id: 'a', rev: 'r' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -371,7 +370,7 @@ describe('accept_patient_reports', () => {
       ];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
-        complete.should.equal(true);
+        complete.should.deep.equal({ ok : true, id: 'a', rev: 'r' });
         putRegistration.callCount.should.equal(1);
         registrations[0].scheduled_tasks[0].responded_to_by.should.deep.equal([doc._id]);
         should.not.exist(registrations[0].scheduled_tasks[1].responded_to_by);
@@ -382,8 +381,8 @@ describe('accept_patient_reports', () => {
 
     it('stores visit UUIDs in an array, since there can be multiple', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
+      putRegistration.callsArgWith(1, null, { ok : true, id: 'a', rev: 'r' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc1 = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -439,14 +438,14 @@ describe('accept_patient_reports', () => {
       sinon.stub(db.medic, 'get').callsArgWith(1, null, registrations);
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc1, config, (err, complete) => {
-        complete.should.equal(true);
+        complete.should.deep.equal({ ok : true, id: 'a', rev: 'r' });
         putRegistration.callCount.should.equal(1);
         should.not.exist(registrations[0].scheduled_tasks[0].responded_to_by);
         registrations[0].scheduled_tasks[1].responded_to_by.should.deep.equal([doc1._id]);
         should.not.exist(registrations[0].scheduled_tasks[2].responded_to_by);
 
         transition._handleReport(doc2, config, (err, complete) => {
-          complete.should.equal(true);
+          complete.should.deep.equal({ ok : true, id: 'a', rev: 'r' });
           putRegistration.callCount.should.equal(2);
           should.not.exist(registrations[0].scheduled_tasks[0].responded_to_by);
           registrations[0].scheduled_tasks[1].responded_to_by.should.deep.equal([doc1._id, doc2._id]);
@@ -458,8 +457,8 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 2.', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
+      putRegistration.callsArgWith(1, null, { ok : true, id: 'a', rev: 'r' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -509,7 +508,7 @@ describe('accept_patient_reports', () => {
       ];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
-        complete.should.equal(true);
+        complete.should.deep.equal({ ok : true, id: 'a', rev: 'r' });
         putRegistration.callCount.should.equal(1);
         should.not.exist(registrations[0].scheduled_tasks[0].responded_to_by);
         registrations[0].scheduled_tasks[1].responded_to_by.should.deep.equal([doc._id]);
@@ -520,8 +519,8 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 3', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
+      putRegistration.callsArgWith(1, null, { ok : true, id: 'a', rev: 'r' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -582,7 +581,7 @@ describe('accept_patient_reports', () => {
       ];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
-        complete.should.equal(true);
+        complete.should.deep.equal({ ok : true, id: 'a', rev: 'r' });
         putRegistration.callCount.should.equal(1);
         should.not.exist(registrations[0].scheduled_tasks[0].responded_to_by);
         should.not.exist(registrations[0].scheduled_tasks[1].responded_to_by);
@@ -593,8 +592,7 @@ describe('accept_patient_reports', () => {
     });
 
     it('does not associate visit to anything since it is within the silence_for range', done => {
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
-      sinon.stub(db.medic, 'put').callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { ok : true, id: 'a', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -320,7 +320,8 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 1', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null);
+      putRegistration.callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -344,8 +345,8 @@ describe('accept_patient_reports', () => {
               group: 1
             },
             {
-              due: '2018-09-28T20:45:00.000Z',
-              state: 'sent',
+              due: '2018-10-28T20:45:00.000Z',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'k',
@@ -381,7 +382,8 @@ describe('accept_patient_reports', () => {
 
     it('stores visit UUIDs in an array, since there can be multiple', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null);
+      putRegistration.callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
       const doc1 = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -456,7 +458,8 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 2.', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null);
+      putRegistration.callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -517,7 +520,8 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 3', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArgWith(1, null);
+      putRegistration.callsArgWith(1, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -589,8 +593,8 @@ describe('accept_patient_reports', () => {
     });
 
     it('does not associate visit to anything since it is within the silence_for range', done => {
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j' });
-      sinon.stub(db.medic, 'put').callsArgWith(1, null);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
+      sinon.stub(db.medic, 'put').callsArgWith(1, null, true);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -695,7 +699,7 @@ describe('accept_patient_reports', () => {
         .stub(transition, '_findToClear')
         .returns(registration.scheduled_tasks);
       const setTaskState = sinon.stub(utils, 'setTaskState');
-      sinon.stub(db.medic, 'post').callsArg(1);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'test-registration', _rev: 'k' });
 
       transition._silenceReminders(registration, report, null, () => {
         registration._id.should.equal('test-registration');
@@ -890,14 +894,14 @@ describe('accept_patient_reports', () => {
           silence_type: 'x',
           silence_for: silence_for,
         });
-        ids(results).should.deep.equal([3, 4, 31, 41]);
+        ids(results).should.deep.equal([2, 3, 4, 31, 41]);
       });
       it('also with multiple types', () => {
         const results = transition._findToClear(registration, now.valueOf(), {
           silence_type: 'x,y',
           silence_for: silence_for,
         });
-        ids(results).should.deep.equal([3, 4, 31, 41, 6, 7]);
+        ids(results).should.deep.equal([2, 3, 4, 31, 41, 6, 7]);
       });
     });
   });

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -321,7 +321,7 @@ describe('accept_patient_reports', () => {
     it('associates visit to Group 1 Message 1', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
       putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -383,7 +383,7 @@ describe('accept_patient_reports', () => {
     it('stores visit UUIDs in an array, since there can be multiple', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
       putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
       const doc1 = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -459,7 +459,7 @@ describe('accept_patient_reports', () => {
     it('associates visit to Group 1 Message 2.', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
       putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -521,7 +521,7 @@ describe('accept_patient_reports', () => {
     it('associates visit to Group 1 Message 3', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
       putRegistration.callsArgWith(1, null, true);
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -593,7 +593,7 @@ describe('accept_patient_reports', () => {
     });
 
     it('does not associate visit to anything since it is within the silence_for range', done => {
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', _rev: 'k' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j', rev: 'k' });
       sinon.stub(db.medic, 'put').callsArgWith(1, null, true);
       const doc = {
         _id: 'z',
@@ -699,7 +699,7 @@ describe('accept_patient_reports', () => {
         .stub(transition, '_findToClear')
         .returns(registration.scheduled_tasks);
       const setTaskState = sinon.stub(utils, 'setTaskState');
-      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'test-registration', _rev: 'k' });
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'test-registration', rev: 'k' });
 
       transition._silenceReminders(registration, report, null, () => {
         registration._id.should.equal('test-registration');

--- a/sentinel/tests/unit/transitions/accept_patient_reports.js
+++ b/sentinel/tests/unit/transitions/accept_patient_reports.js
@@ -200,7 +200,7 @@ describe('accept_patient_reports', () => {
     // Helpful diagram for the next 5 tests:
     // https://github.com/medic/medic/issues/4694#issuecomment-459460521
     it('does not associate visit to anything since no reminder messages have been sent yet', done => {
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, true);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -220,6 +220,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k5',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -230,6 +231,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -240,6 +242,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'j',
                 },
               ],
+              type: 'x',
               group: 1
             },
           ],
@@ -256,7 +259,8 @@ describe('accept_patient_reports', () => {
     });
 
     it('does not associate visit to anything since it is not responding to a reminder', done => {
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j' });
+      sinon.stub(db.medic, 'get').callsArgWith(1, null, true);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -270,32 +274,35 @@ describe('accept_patient_reports', () => {
           scheduled_tasks: [
             {
               due: '2018-09-28T19:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'k5',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2018-10-28T20:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'k',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2018-11-28T21:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'j',
                 },
               ],
+              type: 'x',
               group: 1
             },
           ],
@@ -313,8 +320,7 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 1', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArg(1);
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      putRegistration.callsArgWith(1, null);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -327,33 +333,36 @@ describe('accept_patient_reports', () => {
           reported_date: '2017-02-05T09:23:07.853Z',
           scheduled_tasks: [
             {
-              due: '2018-09-28T18:45:00.000Z',
+              due: '2018-09-18T18:45:00.000Z',
               state: 'sent',
               messages: [
                 {
                   uuid: 'k5',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2018-09-28T20:45:00.000Z',
-              state: 'cleared',
+              state: 'sent',
               messages: [
                 {
                   uuid: 'k',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2018-11-28T21:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'j',
                 },
               ],
+              type: 'x',
               group: 1
             },
           ],
@@ -372,8 +381,7 @@ describe('accept_patient_reports', () => {
 
     it('stores visit UUIDs in an array, since there can be multiple', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArg(1);
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      putRegistration.callsArgWith(1, null);
       const doc1 = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -398,6 +406,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k5',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -408,21 +417,24 @@ describe('accept_patient_reports', () => {
                   uuid: 'k',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2018-11-28T21:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'j',
                 },
               ],
+              type: 'x',
               group: 1
             },
           ],
         },
       ];
+      sinon.stub(db.medic, 'get').callsArgWith(1, null, registrations);
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc1, config, (err, complete) => {
         complete.should.equal(true);
@@ -444,8 +456,7 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 2.', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArg(1);
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      putRegistration.callsArgWith(1, null);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -465,6 +476,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k5',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -475,16 +487,18 @@ describe('accept_patient_reports', () => {
                   uuid: 'k',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2018-11-28T21:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'j',
                 },
               ],
+              type: 'x',
               group: 1
             },
           ],
@@ -503,8 +517,7 @@ describe('accept_patient_reports', () => {
 
     it('associates visit to Group 1 Message 3', done => {
       const putRegistration = sinon.stub(db.medic, 'put');
-      putRegistration.callsArg(1);
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      putRegistration.callsArgWith(1, null);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -524,6 +537,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k1',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -534,6 +548,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k2',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -544,6 +559,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k3',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -554,6 +570,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k4',
                 },
               ],
+              type: 'x',
               group: 2
             },
           ],
@@ -572,7 +589,8 @@ describe('accept_patient_reports', () => {
     });
 
     it('does not associate visit to anything since it is within the silence_for range', done => {
-      sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
+      sinon.stub(db.medic, 'post').callsArgWith(1, null, { _id: 'j' });
+      sinon.stub(db.medic, 'put').callsArgWith(1, null);
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
@@ -592,6 +610,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k1',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -602,6 +621,7 @@ describe('accept_patient_reports', () => {
                   uuid: 'k2',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
@@ -612,21 +632,24 @@ describe('accept_patient_reports', () => {
                   uuid: 'k3',
                 },
               ],
+              type: 'x',
               group: 1
             },
             {
               due: '2019-01-26T18:45:00.000Z',
-              state: 'cleared',
+              state: 'scheduled',
               messages: [
                 {
                   uuid: 'k4',
                 },
               ],
+              type: 'x',
               group: 2
             },
           ],
         },
       ];
+      sinon.stub(db.medic, 'get').callsArgWith(1, null, registrations);
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       transition._handleReport(doc, config, (err, complete) => {
         complete.should.equal(true);
@@ -867,14 +890,14 @@ describe('accept_patient_reports', () => {
           silence_type: 'x',
           silence_for: silence_for,
         });
-        ids(results).should.deep.equal([2, 3, 4, 31, 41]);
+        ids(results).should.deep.equal([3, 4, 31, 41]);
       });
       it('also with multiple types', () => {
         const results = transition._findToClear(registration, now.valueOf(), {
           silence_type: 'x,y',
           silence_for: silence_for,
         });
-        ids(results).should.deep.equal([2, 3, 4, 31, 41, 6, 7]);
+        ids(results).should.deep.equal([3, 4, 31, 41, 6, 7]);
       });
     });
   });


### PR DESCRIPTION
# Description

- reverse sequence between silencing registration and adding report uuid: we don't want to link a report to a reminder that has already been cleared. When tasks are cleared, the field `cleared_by` is added which is enough for the analytics team.

- fix linking logic to prevent conflicts: now if the the second put results in a conflict, we update the `_rev` and re-put.

- fix potential bug with finding the messages to clear: changed when the filter component is applied.  Indeed, if we consider 2 tasks belonging to the same group. The most recent one is `sent` and the oldest want is `scheduled`. The old implementation will clear the second one even though is not in the `silence_for` window but just because the first one is.

- fix tests

medic/medic#4694

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
