### PR TITLE
Runs deletions of read docs serially not in parallel

### DIFF
--- a/sentinel/src/transitions/index.js
+++ b/sentinel/src/transitions/index.js
@@ -122,23 +122,25 @@ const deleteReadDocs = change => {
 
   return db.allDbs().then(dbs => {
     const userDbs = dbs.filter(db => db.indexOf('medic-user-') === 0);
-
-    return Promise.all(userDbs.map(userDb => {
-      const metaDb = db.get(userDb);
-      return metaDb.allDocs({ keys: possibleReadDocIds }).then(results => {
-        const row = results.rows.find(row => !row.error);
-        if (!row) {
-          return;
-        }
-
-        return metaDb.remove(row.id, row.value.rev).catch(err => {
-          // ignore 404s or 409s - the doc was probably deleted client side already
-          if (err && err.status !== 404 && err.status !== 409) {
-            throw err;
+    return userDbs.reduce((p, userDb) => {
+      return p.then(() => {
+        const metaDb = db.get(userDb);
+        return metaDb.allDocs({ keys: possibleReadDocIds }).then(results => {
+          const row = results.rows.find(row => !row.error);
+          if (!row) {
+            return;
           }
+
+          return metaDb.remove(row.id, row.value.rev).catch(err => {
+            // ignore 404s or 409s - the doc was probably deleted client side already
+            if (err && err.status !== 404 && err.status !== 409) {
+              throw err;
+            }
+          });
         });
       });
-    }));
+    }, Promise.resolve());
+
   });
 };
 

--- a/sentinel/tests/unit/transitions.js
+++ b/sentinel/tests/unit/transitions.js
@@ -538,7 +538,7 @@ describe('transitions', () => {
       });
   });
 
-  it('deleteReadDocs deletes read doc for all admins', () => {
+  it('deleteReadDocs deletes read doc for all users', () => {
     const given = { id: 'abc' };
     const metaDb = {
       allDocs: sinon.stub().resolves({


### PR DESCRIPTION
# Description

Running in parallel with a large number of users can fail and
even crash CouchDB. This is slower but much safer.

medic/medic#5420

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
