### PR TITLE
Updates registration LMP, EBD and DOB calculations to be relative to reported_date

### DIFF
--- a/sentinel/src/transitions/registration.js
+++ b/sentinel/src/transitions/registration.js
@@ -152,25 +152,25 @@ module.exports = {
     if (!doc || !doc.fields) {
       return '';
     }
-    const today = moment(date.getDate()).startOf('day');
+    const reportedDate = moment(doc.reported_date).startOf('day');
     const years = parseInt(module.exports.getYearsSinceDOB(doc), 10);
     if (!isNaN(years)) {
-      return today.subtract(years, 'years');
+      return reportedDate.subtract(years, 'years');
     }
     const months = parseInt(module.exports.getMonthsSinceDOB(doc), 10);
     if (!isNaN(months)) {
-      return today.subtract(months, 'months');
+      return reportedDate.subtract(months, 'months');
     }
     const weeks = parseInt(module.exports.getWeeksSinceDOB(doc), 10);
     if (!isNaN(weeks)) {
-      return today.subtract(weeks, 'weeks');
+      return reportedDate.subtract(weeks, 'weeks');
     }
     const days = parseInt(module.exports.getDaysSinceDOB(doc), 10);
     if (!isNaN(days)) {
-      return today.subtract(days, 'days');
+      return reportedDate.subtract(days, 'days');
     }
-    // no given date of birth - return today as it's the best we can do
-    return today;
+    // no given date of birth - return reportedDate as it's the best we can do
+    return reportedDate;
   },
   getYearsSinceDOB: doc => {
     const fields = ['years_since_dob', 'years_since_birth', 'age_in_years'];
@@ -218,7 +218,7 @@ module.exports = {
   },
   setExpectedBirthDate: doc => {
     const lmp = Number(module.exports.getWeeksSinceLMP(doc)),
-      start = moment(date.getDate()).startOf('day');
+      start = moment(doc.reported_date).startOf('day');
     if (lmp === 0) {
       // means baby was already born, chw just wants a registration.
       doc.lmp_date = null;

--- a/sentinel/tests/unit/patient_registration.js
+++ b/sentinel/tests/unit/patient_registration.js
@@ -5,8 +5,7 @@ const _ = require('underscore'),
   transition = require('../../src/transitions/registration'),
   db = require('../../src/db'),
   utils = require('../../src/lib/utils'),
-  transitionUtils = require('../../src/transitions/utils'),
-  date = require('../../src/date');
+  transitionUtils = require('../../src/transitions/utils');
 
 const getMessage = (doc, idx) => {
   if (!doc || !doc.tasks) {
@@ -196,36 +195,40 @@ describe('patient registration', () => {
   });
 
   it('getDOB uses weeks since dob if available', () => {
-    const today = 1474942416907,
-      expected = moment(today)
+    const reported_date = 1474942416907,
+      expected = moment(reported_date)
         .startOf('day')
         .subtract(5, 'weeks')
         .valueOf();
-    sinon.stub(date, 'getDate').returns(today);
     sinon.stub(transition, 'getWeeksSinceDOB').returns('5');
-    assert.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
+    assert.equal(transition.getDOB({ fields: {}, reported_date: reported_date }).valueOf(), expected);
   });
 
   it('getDOB uses days since dob if available', () => {
-    const today = 1474942416907,
-      expected = moment(today)
+    const reported_date = 1474942416907,
+      expected = moment(reported_date)
         .startOf('day')
         .subtract(5, 'days')
         .valueOf();
-    sinon.stub(date, 'getDate').returns(today);
     sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
     sinon.stub(transition, 'getDaysSinceDOB').returns('5');
-    assert.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
+    assert.equal(transition.getDOB({ fields: {}, reported_date: reported_date }).valueOf(), expected);
   });
 
-  it('getDOB falls back to today if necessary', () => {
-    const today = 1474942416907,
-      expected = moment(today)
+  it('getDOB falls back to reported_date if necessary', () => {
+    const reported_date = 1474942416907,
+      expected = moment(reported_date)
         .startOf('day')
         .valueOf();
-    sinon.stub(date, 'getDate').returns(today);
     sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
     sinon.stub(transition, 'getDaysSinceDOB').returns(undefined);
+    assert.equal(transition.getDOB({ fields: {}, reported_date: reported_date }).valueOf(), expected);
+  });
+
+  it('getDOB falls back to be relative to today if no reported date', () => {
+    const expected = moment().startOf('day').subtract(4, 'days').valueOf();
+    sinon.stub(transition, 'getWeeksSinceDOB').returns(undefined);
+    sinon.stub(transition, 'getDaysSinceDOB').returns('4');
     assert.equal(transition.getDOB({ fields: {} }).valueOf(), expected);
   });
 

--- a/sentinel/tests/unit/pregnancy_registration.js
+++ b/sentinel/tests/unit/pregnancy_registration.js
@@ -167,6 +167,17 @@ describe('patient registration', () => {
       assert.equal(doc.expected_date, start.clone().add(30, 'weeks').toISOString());
   });
 
+    it('setExpectedBirthDate sets lmp_date and expected_date correctly when doc has reported_date', () => {
+        const reported_date = moment().subtract(1, 'week');
+        const doc = { fields: { lmp: '5', type: 'data_record' }, reported_date: reported_date.valueOf() };
+
+        transition.setExpectedBirthDate(doc);
+
+        assert(doc.lmp_date);
+        assert.equal(doc.lmp_date, reported_date.clone().startOf('day').subtract(5, 'weeks').toISOString());
+        assert.equal(doc.expected_date, reported_date.clone().startOf('day').add(35, 'weeks').toISOString());
+    });
+
   it('valid adds lmp_date and patient_id', () => {
       var start = moment().startOf('day').subtract(5, 'weeks');
 


### PR DESCRIPTION
# Description

Registration transition used to calculate `last_menstrual_period`, `expected_birth_date` and `date_of_birth` relative to current date at processing time instead of the registration's `reported_date`, resulting in incorrect dates in case Sentinel gets behind or is misconfigured. 

medic/medic#5410

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
