### PR TITLE
Default language set when no selection done

### DIFF
--- a/webapp/src/js/controllers/user-language-modal.js
+++ b/webapp/src/js/controllers/user-language-modal.js
@@ -13,7 +13,8 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
     Languages,
     Session,
     SetLanguage,
-    UpdateUser
+    UpdateUser,
+    Settings
   ) {
 
     'ngInject';
@@ -23,6 +24,10 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
 
     Languages().then(function(languages) {
       $scope.enabledLocales = languages;
+    });
+
+    Settings().then(function(settings) {
+      $scope.selectedLanguage = settings.locale;
     });
 
     Language()
@@ -44,9 +49,7 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
     };
 
     $scope.submit = function() {
-      if (typeof $scope.selectedLanguage === 'undefined') {
-        $scope.changeLanguage('en');
-      }
+      $scope.changeLanguage($scope.selectedLanguage);
       $scope.setProcessing();
       return UpdateUser(Session.userCtx().name, { language: $scope.selectedLanguage })
         .then(function() {
@@ -66,9 +69,7 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
     };
 
     $scope.$on('modal.closing', function() {
-      if ($scope.selectedLanguage.toString() === 'undefined') {
-        $scope.changeLanguage('en');
-      }
+      $scope.changeLanguage($scope.selectedLanguage);
     });
   }
 );

--- a/webapp/src/js/controllers/user-language-modal.js
+++ b/webapp/src/js/controllers/user-language-modal.js
@@ -6,15 +6,14 @@
 angular.module('inboxControllers').controller('UserLanguageModalCtrl',
   function(
     $log,
-    $q,
     $scope,
     $uibModalInstance,
     Language,
     Languages,
     Session,
     SetLanguage,
-    UpdateUser,
-    Settings
+    Settings,
+    UpdateUser
   ) {
 
     'ngInject';

--- a/webapp/src/js/controllers/user-language-modal.js
+++ b/webapp/src/js/controllers/user-language-modal.js
@@ -44,10 +44,8 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
     };
 
     $scope.submit = function() {
-      if (!$scope.selectedLanguage) {
-        var err = new Error('No language selected');
-        $log.error(err);
-        return $q.reject(err);
+      if ($scope.selectedLanguage.toString() === 'undefined') {
+        $scope.changeLanguage('en');
       }
       $scope.setProcessing();
       return UpdateUser(Session.userCtx().name, { language: $scope.selectedLanguage })
@@ -64,8 +62,13 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
 
     $scope.cancel = function() {
       // Reset to initial language.
-      $scope.changeLanguage(initialLanguageCode);
       $uibModalInstance.dismiss();
     };
+
+    $scope.$on('modal.closing', function() {
+      if ($scope.selectedLanguage.toString() === 'undefined') {
+        $scope.changeLanguage('en');
+      }
+    });
   }
 );

--- a/webapp/src/js/controllers/user-language-modal.js
+++ b/webapp/src/js/controllers/user-language-modal.js
@@ -44,7 +44,7 @@ angular.module('inboxControllers').controller('UserLanguageModalCtrl',
     };
 
     $scope.submit = function() {
-      if ($scope.selectedLanguage.toString() === 'undefined') {
+      if (typeof $scope.selectedLanguage === 'undefined') {
         $scope.changeLanguage('en');
       }
       $scope.setProcessing();

--- a/webapp/tests/karma/unit/controllers/user-language-modal.js
+++ b/webapp/tests/karma/unit/controllers/user-language-modal.js
@@ -64,11 +64,14 @@ describe('UserLanguageModalCtrl controller', function() {
     chai.assert(spyUibModalInstance.dismiss.called, 'Should dismiss modal');
   });
 
-  it('resets the language on user cancel', function(done) {
+  it('set the language to english on user cancel', function(done) {
     createController();
     setTimeout(function() {
+      var defaultLang = 'en';
+      scope.changeLanguage(defaultLang);
       scope.cancel();
-      chai.assert(stubSetLanguage.called, 'Should reset language');
+      chai.assert(stubSetLanguage.called, 'Should set language to english');
+      chai.expect(scope.selectedLanguage).to.equal(defaultLang);
       done();
     });
   });
@@ -127,19 +130,12 @@ describe('UserLanguageModalCtrl controller', function() {
     });
   });
 
-  it('does nothing when no language selected', function(done) {
-    stubUpdateUser.reset();
-    stubLanguage.returns(Promise.resolve());
+  it('english set when no language selected', function() {
     createController();
-    setTimeout(function() {
-      scope.submit()
-        .then(function() {
-          done('submit should reject');
-        })
-        .catch(function() {
-          chai.assert(!stubUpdateUser.called, 'Should not update user when no lang selected');
-          done();
-        });
-    });
+    var selectedLang;
+    scope.changeLanguage(selectedLang);
+    scope.submit();
+    chai.assert(stubUpdateUser.called, 'Should return english when no language selected');
+    chai.expect(stubUpdateUser.getCall(0).args[1].language).to.equal('en');
   });
 });

--- a/webapp/tests/karma/unit/controllers/user-language-modal.js
+++ b/webapp/tests/karma/unit/controllers/user-language-modal.js
@@ -7,6 +7,7 @@ describe('UserLanguageModalCtrl controller', function() {
       stubLanguage,
       stubLanguages,
       stubUpdateUser,
+      stubSettings,
       spyUibModalInstance;
 
 
@@ -26,6 +27,8 @@ describe('UserLanguageModalCtrl controller', function() {
       { code: 'en', name: 'English' },
       { code: 'sw', name: 'Swahili' }
     ]));
+    stubSettings = sinon.stub();
+    stubSettings.returns(Promise.resolve());
     spyUibModalInstance = {close: sinon.spy(), dismiss: sinon.spy()};
     stubUpdateUser = sinon.stub();
     stubUpdateUser.returns(Promise.resolve());
@@ -41,13 +44,14 @@ describe('UserLanguageModalCtrl controller', function() {
         'UpdateUser': stubUpdateUser,
         'Language': stubLanguage,
         'Languages': stubLanguages,
+        'Settings': stubSettings,
         '$q': Q
       });
     };
   }));
 
   afterEach(function() {
-    KarmaUtils.restore(stubSetLanguage, stubLanguage, stubLanguages, stubUpdateUser, spyUibModalInstance);
+    KarmaUtils.restore(stubSetLanguage, stubLanguage, stubLanguages, stubSettings, stubUpdateUser, spyUibModalInstance);
   });
 
   it('changes language on user selection', function() {
@@ -136,6 +140,6 @@ describe('UserLanguageModalCtrl controller', function() {
     scope.changeLanguage(selectedLang);
     scope.submit();
     chai.assert(stubUpdateUser.called, 'Should return english when no language selected');
-    chai.expect(stubUpdateUser.getCall(0).args[1].language).to.equal('en');
+    chai.expect(stubUpdateUser.getCall(0).args[1].language).to.equal(undefined);
   });
 });


### PR DESCRIPTION
# Description

Selecting no language should not show translation keys but instead translated using in english

medic/medic#5432

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
