### PR TITLE
Force login for offline users who logout

### DIFF
--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -115,10 +115,6 @@ const setLocaleCookie = (res, locale) => {
   res.cookie('locale', locale, options);
 };
 
-const deleteForceLoginCookie = (res) => {
-  res.clearCookie('login');
-};
-
 const getRedirectUrl = userCtx => {
   // https://github.com/medic/medic/issues/5035
   // For Test DB, always redirect to the application, the tests rely on the UI elements of application page
@@ -143,7 +139,8 @@ const setCookies = (req, res, sessionRes) => {
     .then(userCtx => {
       setSessionCookie(res, sessionCookie);
       setUserCtxCookie(res, userCtx);
-      deleteForceLoginCookie(res);
+      // Delete login=force cookie
+      res.clearCookie('login');
       return auth.getUserSettings(userCtx).then(settings => {
         setLocaleCookie(res, settings.language);
         res.status(302).send(getRedirectUrl(userCtx));
@@ -192,8 +189,7 @@ module.exports = {
       .then(userCtx => {
         // already logged in
         setUserCtxCookie(res, userCtx);
-
-        var hasForceLoginCookie = req.headers.cookie.indexOf('login=force') > -1;
+        var hasForceLoginCookie = cookie.get(req, 'login') === 'force';
         if (hasForceLoginCookie) {
           throw new Error('Force login');
         }

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -115,6 +115,10 @@ const setLocaleCookie = (res, locale) => {
   res.cookie('locale', locale, options);
 };
 
+const deleteForceLoginCookie = (res) => {
+  res.clearCookie('login');
+};
+
 const getRedirectUrl = userCtx => {
   // https://github.com/medic/medic/issues/5035
   // For Test DB, always redirect to the application, the tests rely on the UI elements of application page
@@ -139,10 +143,9 @@ const setCookies = (req, res, sessionRes) => {
     .then(userCtx => {
       setSessionCookie(res, sessionCookie);
       setUserCtxCookie(res, userCtx);
-      return auth.getUserSettings(userCtx).then(({ language }={}) => {
-        if (language) {
-          setLocaleCookie(res, language);
-        }
+      deleteForceLoginCookie(res);
+      return auth.getUserSettings(userCtx).then(settings => {
+        setLocaleCookie(res, settings.language);
         res.status(302).send(getRedirectUrl(userCtx));
       });
     })
@@ -189,6 +192,11 @@ module.exports = {
       .then(userCtx => {
         // already logged in
         setUserCtxCookie(res, userCtx);
+
+        var hasForceLoginCookie = req.headers.cookie.indexOf('login=force') > -1;
+        if (hasForceLoginCookie) {
+          throw new Error('Force login');
+        }
         res.redirect(redirect);
       })
       .catch(() => {

--- a/api/src/services/cookie.js
+++ b/api/src/services/cookie.js
@@ -5,7 +5,7 @@ module.exports = {
       return;
     }
     const prefix = name + '=';
-    const cookie = cookies.split(';').find(cookie => cookie.startsWith(prefix));
-    return cookie && cookie.substring(prefix.length);
+    const cookie = cookies.split(';').find(cookie => cookie.trim().startsWith(prefix));
+    return cookie && cookie.trim().substring(prefix.length);
   }
 };

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -21,14 +21,16 @@ describe('login controller', () => {
     req = {
       query: {},
       body: {},
-      hostname: 'xx.app.medicmobile.org'
+      hostname: 'xx.app.medicmobile.org',
+      headers: {cookie: ''}
     };
     res = {
       redirect: () => {},
       send: () => {},
       status: () => {},
       json: () => {},
-      cookie: () => {}
+      cookie: () => {},
+      clearCookie: () => {}
     };
     originalEnvironment = Object.assign(environment);
 
@@ -250,6 +252,7 @@ describe('login controller', () => {
       const send = sinon.stub(res, 'send');     
       const status = sinon.stub(res, 'status').returns(res);
       const cookie = sinon.stub(res, 'cookie').returns(res);
+      const clearCookie = sinon.stub(res, 'clearCookie').returns(res);
       const userCtx = { name: 'shazza', roles: [ 'project-stuff' ] };
       const getUserCtx = sinon.stub(auth, 'getUserCtx').resolves(userCtx);
       const hasAllPermissions = sinon.stub(auth, 'hasAllPermissions').returns(false);
@@ -277,6 +280,8 @@ describe('login controller', () => {
         chai.expect(cookie.args[2][0]).to.equal('locale');
         chai.expect(cookie.args[2][1]).to.equal('es');
         chai.expect(cookie.args[2][2]).to.deep.equal({ sameSite: 'lax', secure: false, maxAge: 31536000000 });
+        chai.expect(clearCookie.callCount).to.equal(1);
+        chai.expect(clearCookie.args[0][0]).to.equal('login');
       });
     });
 

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -190,6 +190,22 @@ describe('login controller', () => {
         chai.expect(send.args[0][0]).to.equal('LOGIN PAGE GOES HERE. TRANSLATED VALUE.');
       });
     });
+
+    it('when already logged in and login=force cookie is present, render login', () => {
+      const getUserCtx = sinon.stub(auth, 'getUserCtx').resolves({ name: 'josh' });
+      const send = sinon.stub(res, 'send');
+      const cookie = sinon.stub(res, 'cookie').returns(res);
+      req.headers.cookie = 'login=force';
+      return controller.get(req, res).then(() => {
+        chai.expect(getUserCtx.callCount).to.equal(1);
+        chai.expect(getUserCtx.args[0][0]).to.deep.equal(req);
+        chai.expect(cookie.callCount).to.equal(1);
+        chai.expect(cookie.args[0][0]).to.equal('userCtx');
+        chai.expect(cookie.args[0][1]).to.equal('{"name":"josh"}');
+        chai.expect(send.callCount).to.equal(1);
+        chai.expect(send.args[0][0]).to.include('<form id="form" action="/lg/login" method="POST">');
+      });
+    });
   });
 
   describe('post', () => {

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -315,7 +315,7 @@ describe('login controller', () => {
       sinon.stub(auth, 'hasAllPermissions').returns(false);
       sinon.stub(auth, 'getUserSettings').resolves({ });
       return controller.post(req, res).then(() => {
-        chai.expect(cookie.callCount).to.equal(2);
+        chai.expect(cookie.callCount).to.equal(3);
         chai.expect(cookie.args[0][0]).to.equal('AuthSession');
         chai.expect(cookie.args[1][0]).to.equal('userCtx');
       });

--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -127,7 +127,7 @@
   module.exports = function(POUCHDB_OPTIONS, callback) {
     var dbInfo = getDbInfo();
     var userCtx = getUserCtx();
-    var hasForceLoginCookie = document.cookie.indexOf('login=force') > -1;
+    const hasForceLoginCookie = document.cookie.includes('login=force');
     if (!userCtx || hasForceLoginCookie) {
       var err = new Error('User must reauthenticate');
       err.status = 401;

--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -127,7 +127,8 @@
   module.exports = function(POUCHDB_OPTIONS, callback) {
     var dbInfo = getDbInfo();
     var userCtx = getUserCtx();
-    if (!userCtx) {
+    var hasForceLoginCookie = document.cookie.indexOf('login=force') > -1;
+    if (!userCtx || hasForceLoginCookie) {
       var err = new Error('User must reauthenticate');
       err.status = 401;
       return redirectToLogin(dbInfo, err, callback);

--- a/webapp/src/js/services/session.js
+++ b/webapp/src/js/services/session.js
@@ -36,7 +36,8 @@ var COOKIE_NAME = 'userCtx',
       var logout = function() {
         $http.delete('/_session')
           .catch(function() {
-            // Ignore exception. User can already be logged out.
+            // Set cookie to force login before using app
+            ipCookie('login', 'force', { path: '/' });
           })
           .then(navigateToLogin);
       };


### PR DESCRIPTION
# Description

1) Create cookie login=force during offline logout (client side)
2) Prevent users from accessing the app when cookie login=force exist (client side)
3) When the user comes back online, delete cookie and force login (server side)

medic/medic#5183

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
