### PR TITLE
Uglifies more files for fast loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist
 config/standard/.gdrive.*.json
 config/*/backups/*
 api/src/extracted-resources/**/*
+api/build/**/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -845,6 +845,8 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build', 'Build the static resources', [
+    'exec:clean-build-dir',
+    'copy:ddocs',
     'build-node-modules',
     'build-common',
     'minify',
@@ -852,13 +854,13 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build-dev', 'Build the static resources', [
+    'exec:clean-build-dir',
+    'copy:ddocs',
     'build-common',
     'couch-compile:primary',
   ]);
 
   grunt.registerTask('build-common', 'Build the static resources', [
-    'exec:clean-build-dir',
-    'copy:ddocs',
     'mmcss',
     'mmjs',
     'enketo-xslt',
@@ -920,11 +922,10 @@ module.exports = function(grunt) {
     'protractor:performance-tests-and-services',
   ]);
 
-  grunt.registerTask(
-    'unit-continuous',
-    'Lint, karma unit tests running on a loop',
-    ['exec:eslint', 'karma:unit-continuous']
-  );
+  grunt.registerTask('unit-continuous', 'Lint, karma unit tests running on a loop', [
+    'exec:eslint',
+    'karma:unit-continuous'
+  ]);
 
   grunt.registerTask(
     'test-api-integration',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -866,6 +866,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build-dev', 'Build the static resources', [
     'exec:clean-build-dir',
     'copy:ddocs',
+    'copy:api-resources',
     'build-common',
     'couch-compile:primary',
   ]);
@@ -875,7 +876,6 @@ module.exports = function(grunt) {
     'mmjs',
     'enketo-xslt',
     'copy:webapp',
-    'copy:api-resources',
     'exec:set-ddoc-version',
     'exec:set-horticulturalist-metadata',
     'build-admin',
@@ -901,6 +901,7 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build-node-modules', 'Build and pack api and sentinel bundles', [
+    'copy:api-resources',
     'uglify:api',
     'cssmin:api',
     'exec:bundle-dependencies',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,7 +196,7 @@ module.exports = function(grunt) {
           'build/ddocs/medic-admin/_attachments/js/templates.js': 'build/ddocs/medic-admin/_attachments/js/templates.js',
 
           // public api files
-          'api/src/public/login/script.js': 'api/src/public/login/script.js',
+          'api/build/public/login/script.js': 'api/build/public/login/script.js',
         },
       },
     },
@@ -236,10 +236,9 @@ module.exports = function(grunt) {
           keepSpecialComments: 0,
         },
         files: {
-          'build/ddocs/medic/_attachments/css/inbox.css':
-            'build/ddocs/medic/_attachments/css/inbox.css',
-          'build/ddocs/medic-admin/_attachments/css/main.css':
-            'build/ddocs/medic-admin/_attachments/css/main.css',
+          'build/ddocs/medic/_attachments/css/inbox.css': 'build/ddocs/medic/_attachments/css/inbox.css',
+          'build/ddocs/medic-admin/_attachments/css/main.css': 'build/ddocs/medic-admin/_attachments/css/main.css',
+          'api/build/public/login/style.css': 'api/build/public/login/style.css',
         },
       },
     },
@@ -264,24 +263,16 @@ module.exports = function(grunt) {
     },
     copy: {
       ddocs: {
-        files: [
-          {
-            expand: true,
-            cwd: 'ddocs/',
-            src: '**/*',
-            dest: 'build/ddocs/',
-          },
-        ],
+        expand: true,
+        cwd: 'ddocs/',
+        src: '**/*',
+        dest: 'build/ddocs/',
       },
       webapp: {
-        files: [
-          {
-            expand: true,
-            flatten: true,
-            src: 'webapp/node_modules/font-awesome/fonts/*',
-            dest: 'build/ddocs/medic/_attachments/fonts/',
-          },
-        ],
+        expand: true,
+        flatten: true,
+        src: 'webapp/node_modules/font-awesome/fonts/*',
+        dest: 'build/ddocs/medic/_attachments/fonts/',
       },
       'inbox-file-attachment': {
         expand: true,
@@ -290,20 +281,22 @@ module.exports = function(grunt) {
         dest: 'build/ddocs/medic/_attachments/',
       },
       'ddoc-attachments': {
-        files: [
-          {
-            expand: true,
-            cwd: 'webapp/src/',
-            src: [
-              'audio/**/*',
-              'fonts/**/*',
-              'img/**/*',
-              'templates/inbox.html',
-              'ddocs/medic/_attachments/**/*',
-            ],
-            dest: 'build/ddocs/medic/_attachments/',
-          },
+        expand: true,
+        cwd: 'webapp/src/',
+        src: [
+          'audio/**/*',
+          'fonts/**/*',
+          'img/**/*',
+          'templates/inbox.html',
+          'ddocs/medic/_attachments/**/*',
         ],
+        dest: 'build/ddocs/medic/_attachments/',
+      },
+      'api-resources': {
+        expand: true,
+        cwd: 'api/src/public/',
+        src: '**/*',
+        dest: 'api/build/public/',
       },
       'admin-resources': {
         files: [
@@ -316,35 +309,30 @@ module.exports = function(grunt) {
           {
             expand: true,
             flatten: true,
-            src: ['admin/node_modules/font-awesome/fonts/*', 'webapp/src/fonts/**/*'],
+            src: [
+              'admin/node_modules/font-awesome/fonts/*',
+              'webapp/src/fonts/**/*'
+            ],
             dest: 'build/ddocs/medic-admin/_attachments/fonts/',
           },
         ],
       },
       'libraries-to-patch': {
-        files: [
-          {
-            expand: true,
-            cwd: 'webapp/node_modules',
-            src: [
-              'bootstrap-daterangepicker/**',
-              'enketo-core/**',
-              'font-awesome/**',
-              'moment/**',
-            ],
-            dest: 'webapp/node_modules_backup',
-          },
+        expand: true,
+        cwd: 'webapp/node_modules',
+        src: [
+          'bootstrap-daterangepicker/**',
+          'enketo-core/**',
+          'font-awesome/**',
+          'moment/**',
         ],
+        dest: 'webapp/node_modules_backup',
       },
       'enketo-xslt': {
-        files: [
-          {
-            expand: true,
-            flatten: true,
-            src: 'webapp/node_modules/medic-enketo-xslt/xsl/*.xsl',
-            dest: 'build/ddocs/medic/_attachments/xslt/',
-          },
-        ],
+        expand: true,
+        flatten: true,
+        src: 'webapp/node_modules/medic-enketo-xslt/xsl/*.xsl',
+        dest: 'build/ddocs/medic/_attachments/xslt/',
       },
     },
     exec: {
@@ -370,6 +358,7 @@ module.exports = function(grunt) {
           const ignore = [
             'webapp/src/js/modules/xpath-element-path.js',
             'api/src/extracted-resources/**/*',
+            'api/build/**/*',
             '**/node_modules/**',
             'sentinel/src/lib/pupil/**',
             'build/**',
@@ -877,6 +866,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build-common', 'Build the static resources', [
     'copy:webapp',
+    'copy:api-resources',
     'exec:set-ddoc-version',
     'exec:set-horticulturalist-metadata',
     'build-admin',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -186,10 +186,17 @@ module.exports = function(grunt) {
       },
       build: {
         files: {
+          // webapp files
           'build/ddocs/medic/_attachments/js/templates.js': 'build/ddocs/medic/_attachments/js/templates.js',
           'build/ddocs/medic/_attachments/js/inbox.js': 'build/ddocs/medic/_attachments/js/inbox.js',
+          'build/ddocs/medic/_attachments/js/service-worker.js': 'build/ddocs/medic/_attachments/js/service-worker.js',
+
+          // admin files
           'build/ddocs/medic-admin/_attachments/js/main.js': 'build/ddocs/medic-admin/_attachments/js/main.js',
           'build/ddocs/medic-admin/_attachments/js/templates.js': 'build/ddocs/medic-admin/_attachments/js/templates.js',
+
+          // public api files
+          'api/src/public/login/script.js': 'api/src/public/login/script.js',
         },
       },
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -851,8 +851,8 @@ module.exports = function(grunt) {
     'mmcss',
     'mmjs',
     'enketo-xslt',
-    'minify',
     'build-common',
+    'minify',
   ]);
 
   grunt.registerTask('build-dev', 'Build the static resources', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,7 +184,7 @@ module.exports = function(grunt) {
         banner:
           '/*! Medic Mobile <%= grunt.template.today("yyyy-mm-dd") %> */\n',
       },
-      build: {
+      web: {
         files: {
           // webapp files
           'build/ddocs/medic/_attachments/js/templates.js': 'build/ddocs/medic/_attachments/js/templates.js',
@@ -194,11 +194,14 @@ module.exports = function(grunt) {
           // admin files
           'build/ddocs/medic-admin/_attachments/js/main.js': 'build/ddocs/medic-admin/_attachments/js/main.js',
           'build/ddocs/medic-admin/_attachments/js/templates.js': 'build/ddocs/medic-admin/_attachments/js/templates.js',
-
-          // public api files
-          'api/build/public/login/script.js': 'api/build/public/login/script.js',
         },
       },
+      api: {
+        files: {
+          // public api files
+          'api/build/public/login/script.js': 'api/build/public/login/script.js',
+        }
+      }
     },
     env: {
       'unit-test': {
@@ -231,16 +234,23 @@ module.exports = function(grunt) {
       },
     },
     cssmin: {
-      all: {
+      web: {
         options: {
           keepSpecialComments: 0,
         },
         files: {
           'build/ddocs/medic/_attachments/css/inbox.css': 'build/ddocs/medic/_attachments/css/inbox.css',
           'build/ddocs/medic-admin/_attachments/css/main.css': 'build/ddocs/medic-admin/_attachments/css/main.css',
-          'api/build/public/login/style.css': 'api/build/public/login/style.css',
         },
       },
+      api: {
+        options: {
+          keepSpecialComments: 0,
+        },
+        files: {
+          'api/build/public/login/style.css': 'api/build/public/login/style.css',
+        },
+      }
     },
     postcss: {
       options: {
@@ -891,6 +901,8 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build-node-modules', 'Build and pack api and sentinel bundles', [
+    'uglify:api',
+    'cssmin:api',
     'exec:bundle-dependencies',
     'exec:pack-node-modules',
   ]);
@@ -927,15 +939,11 @@ module.exports = function(grunt) {
     'karma:unit-continuous'
   ]);
 
-  grunt.registerTask(
-    'test-api-integration',
-    'Integration tests for medic-api',
-    [
-      'exec:check-env-vars',
-      'exec:setup-api-integration',
-      'mochaTest:api-integration',
-    ]
-  );
+  grunt.registerTask('test-api-integration', 'Integration tests for medic-api', [
+    'exec:check-env-vars',
+    'exec:setup-api-integration',
+    'mochaTest:api-integration',
+  ]);
 
   grunt.registerTask('unit', 'Unit tests', [
     'karma:unit',
@@ -954,13 +962,13 @@ module.exports = function(grunt) {
 
   // CI tasks
   grunt.registerTask('minify', 'Minify JS and CSS', [
-    'uglify',
+    'uglify:web',
     'optimize-js',
-    'cssmin',
+    'cssmin:web',
     'exec:bundlesize',
   ]);
 
-  grunt.registerTask('ci-compile', 'build, minify, lint, unit, integration test', [
+  grunt.registerTask('ci-compile', 'build, lint, unit, integration test', [
     'install-dependencies',
     'build',
     'build-admin',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -845,26 +845,23 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build', 'Build the static resources', [
-    'exec:clean-build-dir',
-    'copy:ddocs',
     'build-node-modules',
-    'mmcss',
-    'mmjs',
-    'enketo-xslt',
     'build-common',
     'minify',
+    'couch-compile:primary',
   ]);
 
   grunt.registerTask('build-dev', 'Build the static resources', [
+    'build-common',
+    'couch-compile:primary',
+  ]);
+
+  grunt.registerTask('build-common', 'Build the static resources', [
     'exec:clean-build-dir',
     'copy:ddocs',
     'mmcss',
     'mmjs',
     'enketo-xslt',
-    'build-common',
-  ]);
-
-  grunt.registerTask('build-common', 'Build the static resources', [
     'copy:webapp',
     'copy:api-resources',
     'exec:set-ddoc-version',
@@ -877,7 +874,6 @@ module.exports = function(grunt) {
     'couch-compile:secondary',
     'copy:ddoc-attachments',
     'generate-service-worker',
-    'couch-compile:primary',
   ]);
 
   grunt.registerTask('build-admin', 'Build the admin app', [
@@ -892,11 +888,10 @@ module.exports = function(grunt) {
     'notify:deployed',
   ]);
 
-  grunt.registerTask(
-    'build-node-modules',
-    'Build and pack api and sentinel bundles',
-    ['exec:bundle-dependencies', 'exec:pack-node-modules']
-  );
+  grunt.registerTask('build-node-modules', 'Build and pack api and sentinel bundles', [
+    'exec:bundle-dependencies',
+    'exec:pack-node-modules',
+  ]);
 
   // Test tasks
   grunt.registerTask('e2e-deploy', 'Deploy app for testing', [
@@ -920,6 +915,7 @@ module.exports = function(grunt) {
     'exec:reset-test-databases',
     'build-node-modules',
     'build-ddoc',
+    'couch-compile:primary',
     'couch-push:test',
     'protractor:performance-tests-and-services',
   ]);
@@ -949,11 +945,11 @@ module.exports = function(grunt) {
     'env:general',
   ]);
 
-  grunt.registerTask(
-    'test',
-    'Lint, unit tests, api-integration tests and e2e tests',
-    ['unit', 'test-api-integration', 'e2e']
-  );
+  grunt.registerTask('test', 'Lint, unit tests, api-integration tests and e2e tests', [
+    'unit',
+    'test-api-integration',
+    'e2e',
+  ]);
 
   // CI tasks
   grunt.registerTask('minify', 'Minify JS and CSS', [
@@ -997,13 +993,15 @@ module.exports = function(grunt) {
     'exec:audit-whitelist',
   ]);
 
-  grunt.registerTask('eslint', 'Runs eslint', ['exec:eslint']);
+  grunt.registerTask('eslint', 'Runs eslint', [
+    'exec:eslint'
+  ]);
 
-  grunt.registerTask(
-    'dev-webapp-no-dependencies',
-    'Build and deploy the webapp for dev, without reinstalling dependencies.',
-    ['build-dev', 'deploy', 'watch']
-  );
+  grunt.registerTask('dev-webapp-no-dependencies', 'Build and deploy the webapp for dev, without reinstalling dependencies.', [
+    'build-dev',
+    'deploy',
+    'watch',
+  ]);
 
   grunt.registerTask('dev-api', 'Run api and watch for file changes', [
     'exec:api-dev',
@@ -1013,11 +1011,9 @@ module.exports = function(grunt) {
     'exec:setup-admin',
   ]);
 
-  grunt.registerTask(
-    'dev-sentinel',
-    'Run sentinel and watch for file changes',
-    ['exec:sentinel-dev']
-  );
+  grunt.registerTask('dev-sentinel', 'Run sentinel and watch for file changes', [
+    'exec:sentinel-dev',
+  ]);
 
   grunt.registerTask('publish-for-testing', 'Publish the ddoc to the testing server', [
     'replace:change-ddoc-id-for-testing',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -837,13 +837,13 @@ module.exports = function(grunt) {
     'exec:apply-patches',
   ]);
 
-  grunt.registerTask('mmjs', 'Build the JS resources', [
+  grunt.registerTask('build-js', 'Build the JS resources', [
     'browserify:webapp',
     'replace:update-app-constants',
     'ngtemplates:inboxApp',
   ]);
 
-  grunt.registerTask('mmcss', 'Build the CSS resources', [
+  grunt.registerTask('build-css', 'Build the CSS resources', [
     'sass',
     'less:webapp',
     'postcss',
@@ -872,8 +872,8 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build-common', 'Build the static resources', [
-    'mmcss',
-    'mmjs',
+    'build-css',
+    'build-js',
     'enketo-xslt',
     'copy:webapp',
     'exec:set-ddoc-version',
@@ -935,8 +935,7 @@ module.exports = function(grunt) {
     'protractor:performance-tests-and-services',
   ]);
 
-  grunt.registerTask('unit-continuous', 'Lint, karma unit tests running on a loop', [
-    'exec:eslint',
+  grunt.registerTask('unit-continuous', 'Run karma unit tests in a loop', [
     'karma:unit-continuous'
   ]);
 
@@ -955,7 +954,7 @@ module.exports = function(grunt) {
     'env:general',
   ]);
 
-  grunt.registerTask('test', 'Lint, unit tests, api-integration tests and e2e tests', [
+  grunt.registerTask('test', 'Run unit, integration, and e2e tests', [
     'unit',
     'test-api-integration',
     'e2e',

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -189,7 +189,7 @@ app.get('/favicon.ico', (req, res) => {
   });
 });
 
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, '../build/public')));
 app.use(express.static(path.join(__dirname, 'extracted-resources')));
 app.get(routePrefix + 'login', login.get);
 app.get(routePrefix + 'login/identity', login.getIdentity);


### PR DESCRIPTION
# Description

- adds uglifying for login/script.js and service-worker.js
- adds cssmin for login/styles.css
- fixes a bug where uglifying was happening too early on webapp code so files weren't being minified at all
- reformats the Gruntfile for consistency

#5489

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
