### PR TITLE
Cleans up only old build artefacts

### DIFF
--- a/scripts/travis/cleanup.js
+++ b/scripts/travis/cleanup.js
@@ -33,6 +33,12 @@ const remove = docs => {
   }
 };
 
+const cleanDb = () => {
+  console.log('Compacting DB...');
+  return db.compact();
+};
+
 get()
   .then(markDeleted)
-  .then(remove);
+  .then(remove)
+  .then(cleanDb);

--- a/scripts/travis/cleanup.js
+++ b/scripts/travis/cleanup.js
@@ -1,22 +1,38 @@
 /*
- * Delete the artefact from the testing db
+ * Delete old artefacts from the testing db
  */
-
 const { UPLOAD_URL, TRAVIS_BUILD_NUMBER } = process.env;
+const BUILDS_TO_KEEP = 50;
+const END_BUILD_TO_DELETE = TRAVIS_BUILD_NUMBER - BUILDS_TO_KEEP;
+const END_KEY = `medic:medic:test-${END_BUILD_TO_DELETE}`;
+const MAX_BUILDS_TO_DELETE = 50;
 const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 
 const db = new PouchDB(`${UPLOAD_URL}/_couch/builds_testing`);
-const docId = `medic:medic:test-${TRAVIS_BUILD_NUMBER}`;
 
 const get = () => {
-  console.log(`Getting "${docId}"...`);
-  return db.get(docId);
+  console.log(`Getting builds...`);
+  return db.allDocs({ endkey: END_KEY, limit: MAX_BUILDS_TO_DELETE });
 };
 
-const remove = doc => {
-  console.log(`Deleting "${docId}"...`);
-  return db.remove(doc);
+const markDeleted = response => {
+  return response.rows.map(row => {
+    return {
+      _id: row.id,
+      _rev: row.value.rev,
+      _deleted: true
+    };
+  });
 };
 
-get().then(remove);
+const remove = docs => {
+  if (docs.length) {
+    console.log(`Deleting the oldest ${docs.length} builds...`);
+    return db.bulkDocs(docs);
+  }
+};
+
+get()
+  .then(markDeleted)
+  .then(remove);


### PR DESCRIPTION
# Description

Instead of trying to delete the artefact from _this_ build, this PR deletes the 50 oldest builds up to 50 build numbers before this build. This has the added benefit of cleaning up any missed artefacts to keep the db under control.

medic/medic#5297

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
