### PR TITLE
Adds `can_update_reports` permission.

### DIFF
--- a/api/src/config.default.json
+++ b/api/src/config.default.json
@@ -110,6 +110,12 @@
     "can_edit_profile": ["national_admin", "district_admin"],
     "can_delete_reports": ["national_admin", "district_admin"],
     "can_bulk_delete_reports": ["national_admin", "district_admin"],
+    "can_update_reports": [
+      "national_admin",
+      "district_admin",
+      "data_entry",
+      "gateway"
+    ],
     "can_delete_contacts": ["national_admin", "district_admin"],
     "can_delete_messages": ["national_admin", "district_admin"],
     "can_delete_users": ["national_admin"],

--- a/api/src/config.default.json
+++ b/api/src/config.default.json
@@ -110,12 +110,7 @@
     "can_edit_profile": ["national_admin", "district_admin"],
     "can_delete_reports": ["national_admin", "district_admin"],
     "can_bulk_delete_reports": ["national_admin", "district_admin"],
-    "can_update_reports": [
-      "national_admin",
-      "district_admin",
-      "data_entry",
-      "gateway"
-    ],
+    "can_update_reports": ["national_admin", "district_admin"],
     "can_delete_contacts": ["national_admin", "district_admin"],
     "can_delete_messages": ["national_admin", "district_admin"],
     "can_delete_users": ["national_admin"],

--- a/config/standard/app_settings.json
+++ b/config/standard/app_settings.json
@@ -192,6 +192,12 @@
       "national_admin",
       "district_admin"
     ],
+    "can_update_reports": [
+      "national_admin",
+      "district_admin",
+      "data_entry",
+      "gateway"
+    ],
     "can_delete_contacts": [
       "national_admin",
       "district_admin"

--- a/config/standard/app_settings.json
+++ b/config/standard/app_settings.json
@@ -194,9 +194,7 @@
     ],
     "can_update_reports": [
       "national_admin",
-      "district_admin",
-      "data_entry",
-      "gateway"
+      "district_admin"
     ],
     "can_delete_contacts": [
       "national_admin",

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -134,16 +134,17 @@ _.templateSettings = {
     contacts: 'can_view_contacts',
     analytics: 'can_view_analytics',
     reports: 'can_view_reports',
+    'reports.edit': 'can_update_reports'
   };
 
   var getRequiredPermission = function(route) {
-    var baseRoute = route.split('.')[0];
+    var baseRoute = route in ROUTE_PERMISSIONS ? route : route.split('.')[0];
     return ROUTE_PERMISSIONS[baseRoute];
   };
 
   // Detects reloads or route updates (#/something)
   angular.module('inboxApp').run(function($state, $transitions, Auth) {
-    $transitions.onStart({}, function(trans) {
+    $transitions.onBefore({}, function(trans) {
       if (trans.to().name.indexOf('error') === -1) {
         var permission = getRequiredPermission(trans.to().name);
         if (permission) {

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -134,21 +134,20 @@ _.templateSettings = {
     contacts: 'can_view_contacts',
     analytics: 'can_view_analytics',
     reports: 'can_view_reports',
-    'reports.edit': 'can_update_reports'
+    'reports.edit': ['can_update_reports', 'can_view_reports']
   };
 
-  var getRequiredPermission = function(route) {
-    var baseRoute = route.split('.')[0];
-    return _.uniq(_.compact([ROUTE_PERMISSIONS[baseRoute], ROUTE_PERMISSIONS[route]]));
+  var getRequiredPermissions = function(route) {
+    return ROUTE_PERMISSIONS[route] || ROUTE_PERMISSIONS[route.split('.')[0]];
   };
 
   // Detects reloads or route updates (#/something)
   angular.module('inboxApp').run(function($state, $transitions, Auth) {
     $transitions.onBefore({}, function(trans) {
       if (trans.to().name.indexOf('error') === -1) {
-        var permission = getRequiredPermission(trans.to().name);
-        if (permission && permission.length) {
-          return Auth(permission).catch(function() {
+        const permissions = getRequiredPermissions(trans.to().name);
+        if (permissions && permissions.length) {
+          return Auth(permissions).catch(function() {
             return $state.target('error', { code: 403 });
           });
         }

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -148,8 +148,8 @@ _.templateSettings = {
       if (trans.to().name.indexOf('error') === -1) {
         var permission = getRequiredPermission(trans.to().name);
         if (permission) {
-          Auth(permission).catch(function() {
-            $state.go('error', { code: 403 });
+          return Auth(permission).catch(function() {
+            return $state.target('error', { code: 403 });
           });
         }
       }

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -138,8 +138,8 @@ _.templateSettings = {
   };
 
   var getRequiredPermission = function(route) {
-    var baseRoute = route in ROUTE_PERMISSIONS ? route : route.split('.')[0];
-    return ROUTE_PERMISSIONS[baseRoute];
+    var baseRoute = route.split('.')[0];
+    return _.uniq(_.compact([ROUTE_PERMISSIONS[baseRoute], ROUTE_PERMISSIONS[route]]));
   };
 
   // Detects reloads or route updates (#/something)
@@ -147,7 +147,7 @@ _.templateSettings = {
     $transitions.onBefore({}, function(trans) {
       if (trans.to().name.indexOf('error') === -1) {
         var permission = getRequiredPermission(trans.to().name);
-        if (permission) {
+        if (permission && permission.length) {
           return Auth(permission).catch(function() {
             return $state.target('error', { code: 403 });
           });

--- a/webapp/src/templates/directives/actionbar.html
+++ b/webapp/src/templates/directives/actionbar.html
@@ -114,7 +114,7 @@
               <span class="fa fa-check"></span>
               <p translate>reports.verify</p>
             </a>
-            <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.right.type === 'xml'" ui-sref="reports.edit({ reportId: actionBar.right.selected[0]._id })">
+            <a class="mm-icon mm-icon-inverse mm-icon-caption" ng-show="actionBar.right.type === 'xml'" mm-auth="can_update_reports" ui-sref="reports.edit({ reportId: actionBar.right.selected[0]._id })">
               <span class="fa fa-pencil"></span>
               <p translate>Edit</p>
             </a>


### PR DESCRIPTION
# Description

- all default roles have this permission
- hides `edit` button in Reports actionbar
- redirects to `error/403` on route transition
- improves route permissions transitions handling

medic/medic#5537

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
