### PR TITLE
3986 - Make login page available offline

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -269,6 +269,7 @@ module.exports = function(grunt) {
     'generate-service-worker': {
       config: {
         staticDirectoryPath: 'build/ddocs/medic/_attachments',
+        apiSrcDirectoryPath: 'api/src',
         scriptOutputPath: 'build/ddocs/medic/_attachments/js/service-worker.js',
       }
     },

--- a/grunt/service-worker.js
+++ b/grunt/service-worker.js
@@ -14,7 +14,7 @@ function registerServiceWorkerTasks(grunt) {
 }
 
 // Use the swPrecache library to generate a service-worker script
-function writeServiceWorkerFile({staticDirectoryPath, rootUrl, apiSrcDirectoryPath, scriptOutputPath}) {
+function writeServiceWorkerFile({staticDirectoryPath, apiSrcDirectoryPath, scriptOutputPath}) {
   const config = {
     cacheId: 'cache',
     claimsClient: true,
@@ -26,14 +26,14 @@ function writeServiceWorkerFile({staticDirectoryPath, rootUrl, apiSrcDirectoryPa
       path.join(staticDirectoryPath, 'manifest.json'),
 
       // Fonts
-      path.join(__dirname, 'fonts', 'fontawesome-webfont.woff2'),
-      path.join(__dirname, 'fonts', 'enketo-icons-v2.woff'),
-      path.join(__dirname, 'fonts', 'NotoSans-Bold.ttf'),
-      path.join(__dirname, 'fonts', 'NotoSans-Regular.ttf'),
+      path.join(staticDirectoryPath, 'fonts', 'fontawesome-webfont.woff2'),
+      path.join(staticDirectoryPath, 'fonts', 'enketo-icons-v2.woff'),
+      path.join(staticDirectoryPath, 'fonts', 'NotoSans-Bold.ttf'),
+      path.join(staticDirectoryPath, 'fonts', 'NotoSans-Regular.ttf'),
       path.join(apiSrcDirectoryPath, 'public/login', '*.{css,js}'),
     ],
     dynamicUrlToDependencies: {
-      [rootUrl]: [path.join(staticDirectoryPath, 'templates', 'inbox.html')],
+      '/': [path.join(staticDirectoryPath, 'templates', 'inbox.html')],
       '/medic/login': [path.join(apiSrcDirectoryPath, 'templates/login', 'index.html')],
     },
     ignoreUrlParametersMatching: [/redirect/],

--- a/grunt/service-worker.js
+++ b/grunt/service-worker.js
@@ -4,8 +4,7 @@ const path = require('path');
 function registerServiceWorkerTasks(grunt) {
   grunt.registerMultiTask('generate-service-worker', function() {
     const done = this.async();
-    const { staticDirectoryPath, scriptOutputPath } = this.data;
-    writeServiceWorkerFile(staticDirectoryPath, scriptOutputPath)
+    writeServiceWorkerFile(this.data)
       .then(done)
       .catch(error => {
         grunt.fail.warn(error);
@@ -15,7 +14,7 @@ function registerServiceWorkerTasks(grunt) {
 }
 
 // Use the swPrecache library to generate a service-worker script
-function writeServiceWorkerFile(staticDirectoryPath, outputPath) {
+function writeServiceWorkerFile({staticDirectoryPath, rootUrl, apiSrcDirectoryPath, scriptOutputPath}) {
   const config = {
     cacheId: 'cache',
     claimsClient: true,
@@ -31,17 +30,23 @@ function writeServiceWorkerFile(staticDirectoryPath, outputPath) {
       path.join(__dirname, 'fonts', 'enketo-icons-v2.woff'),
       path.join(__dirname, 'fonts', 'NotoSans-Bold.ttf'),
       path.join(__dirname, 'fonts', 'NotoSans-Regular.ttf'),
+      path.join(apiSrcDirectoryPath, 'public/login', '*.{css,js}'),
     ],
     dynamicUrlToDependencies: {
-      '/': [path.join(staticDirectoryPath, 'templates', 'inbox.html')],
+      [rootUrl]: [path.join(staticDirectoryPath, 'templates', 'inbox.html')],
+      '/medic/login': [path.join(apiSrcDirectoryPath, 'templates/login', 'index.html')],
     },
+    ignoreUrlParametersMatching: [/redirect/],
     templateFilePath: path.join(__dirname, 'service-worker.tmpl'),
-    stripPrefixMulti: { [staticDirectoryPath]: '' },
+    stripPrefixMulti: {
+      [staticDirectoryPath]: '',
+      [path.join(apiSrcDirectoryPath, 'public')]: '',
+    },
     maximumFileSizeToCacheInBytes: 1048576 * 20,
     verbose: true,
   };
 
-  return swPrecache.write(outputPath, config);
+  return swPrecache.write(scriptOutputPath, config);
 }
 
 module.exports = registerServiceWorkerTasks;


### PR DESCRIPTION
# Description

Although #3986 isn't officially schedule in 3.5, this is a requirement which we missed from #5183 (scheduled in 3.5). https://github.com/medic/medic/issues/5183#issuecomment-454589247

From @garethbowen:
> Related: #3986 . We should make sure this is fixed at the same time.

I forgot about this when reviewing @wtekeu's fix for 5183 (logging out while offline). But since that one is all wrapped up and reviewed, I'm spinning off another PR for this.  Unsure if we'd want to bring #3986 into the release for easier AT tracking.

This won't work on developer machines in master if they are using a database which is not `medic`, but I merged it with #5448 and it does work without modification when combined with that change.

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
