### PR TITLE
Fix bug with call html()

### DIFF
--- a/webapp/src/js/enketo/widgets/notewidget.js
+++ b/webapp/src/js/enketo/widgets/notewidget.js
@@ -72,7 +72,7 @@ define( function( require, exports, module ) {
     function applyLiveLinkHtml( $el ) {
         // The html may include form inputs with values set via javascript,
         // explicitly set value attributes otherwise call html() won't include them
-        $el.find(`input[type='text']`).each(function () {
+        $el.find('input').each(function () {
           $(this).attr('value', $(this).val());
         });
 

--- a/webapp/src/js/enketo/widgets/notewidget.js
+++ b/webapp/src/js/enketo/widgets/notewidget.js
@@ -74,7 +74,7 @@ define( function( require, exports, module ) {
         // explicitly set value attributes otherwise call html() won't include them
         $el.find(`input[type='text']`).each(function () {
           $(this).attr('value', $(this).val());
-        })
+        });
 
         var html = $el.html();
 

--- a/webapp/src/js/enketo/widgets/notewidget.js
+++ b/webapp/src/js/enketo/widgets/notewidget.js
@@ -70,6 +70,12 @@ define( function( require, exports, module ) {
     // Replace any markdown-style links containing HTML with hrefs which are
     // generated when the link is clicked.
     function applyLiveLinkHtml( $el ) {
+        // The html may include form inputs with values set via javascript,
+        // explicitly set value attributes otherwise call html() won't include them
+        $el.find(`input[type='text']`).each(function () {
+          $(this).attr('value', $(this).val());
+        })
+
         var html = $el.html();
 
         html = html.replace( /\[([^\]]*)\]\(([^)]*<[^>]*>[^)]*)\)/gm,


### PR DESCRIPTION
# Description

Fix bug in notewidget plugin related to html() call  when applying live link html

medic/medic#5536

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
