### PR TITLE
Calculate targets based of UHC month_start_date.

### DIFF
--- a/api/src/config.default.json
+++ b/api/src/config.default.json
@@ -127,9 +127,9 @@
     "debounce_interval": 200
   },
   "uhc": {
+    "month_start_date": 1,
     "contacts_default_sort": "",
     "visit_count": {
-      "month_start_date": 1,
       "visit_count_goal": 0
     }
   },

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -28,6 +28,7 @@ var _ = require('underscore'),
     Simprints,
     Tour,
     TranslateFrom,
+    UHCSettings,
     UserSettings,
     XmlForms
   ) {
@@ -421,27 +422,15 @@ var _ = require('underscore'),
         });
     };
 
-    var getVisitCountSettings = function(uhcSettings) {
-      if (!uhcSettings.visit_count) {
-        return {};
-      }
-
-      return {
-        monthStartDate: uhcSettings.visit_count.month_start_date,
-        visitCountGoal: uhcSettings.visit_count.visit_count_goal,
-      };
-    };
-
     var setupPromise = $q
       .all([getUserHomePlaceSummary(), canViewLastVisitedDate(), Settings()])
-      .then(function(results) {
-        usersHomePlace = results[0];
-        $scope.lastVisitedDateExtras = results[1];
-        var uhcSettings = (results[2] && results[2].uhc) || {};
-        $scope.visitCountSettings = getVisitCountSettings(uhcSettings);
-        if ($scope.lastVisitedDateExtras && uhcSettings.contacts_default_sort) {
-          $scope.sortDirection = $scope.defaultSortDirection =
-            uhcSettings.contacts_default_sort;
+      .then(([ homePlaceSummary, viewLastVisitedDate, settings ]) => {
+        usersHomePlace = homePlaceSummary;
+        $scope.lastVisitedDateExtras = viewLastVisitedDate;
+        $scope.visitCountSettings = UHCSettings.getVisitCountSettings(settings);
+
+        if ($scope.lastVisitedDateExtras && UHCSettings.getContactsDefaultSort(settings)) {
+          $scope.sortDirection = $scope.defaultSortDirection = UHCSettings.getContactsDefaultSort(settings);
         }
 
         setActionBarData();

--- a/webapp/src/js/services/index.js
+++ b/webapp/src/js/services/index.js
@@ -87,6 +87,7 @@
   require('./translate-from');
   require('./translation-loader');
   require('./translation-null-interpolation');
+  require('./uhc-settings');
   require('./unread-records');
   require('./update-facility');
   require('./update-service-worker');

--- a/webapp/src/js/services/target-generator.js
+++ b/webapp/src/js/services/target-generator.js
@@ -10,14 +10,17 @@ var moment = require('moment'),
       $log,
       $parse,
       $q,
+      CalendarInterval,
       RulesEngine,
       Settings,
+      UHCSettings,
       UserContact
     ) {
 
       'ngInect';
 
       var targets = [];
+      let relevantInterval;
 
       var isRelevant = function(instance) {
         if (!instance.date) {
@@ -27,10 +30,8 @@ var moment = require('moment'),
         if (instance.deleted) {
           return false;
         }
-        var start = moment().startOf('month');
-        var end = moment().endOf('month');
         var instanceDate = moment(instance.date);
-        return instanceDate.isAfter(start) && instanceDate.isBefore(end);
+        return instanceDate.isAfter(relevantInterval.start) && instanceDate.isBefore(relevantInterval.end);
       };
 
       var calculatePercent = function(pass, total) {
@@ -72,11 +73,13 @@ var moment = require('moment'),
       };
 
       var init = $q.all([ Settings(), UserContact() ])
-        .then(function(results) {
-          var items = results[0].tasks &&
-                      results[0].tasks.targets &&
-                      results[0].tasks.targets.items;
-          var userContact = results[1];
+        .then(([settings, userContact]) => {
+          var items = settings.tasks &&
+                      settings.tasks.targets &&
+                      settings.tasks.targets.items;
+
+          relevantInterval = CalendarInterval.getCurrent(UHCSettings.getMonthStartDate(settings));
+
           if (!items) {
             targets = [];
             return;

--- a/webapp/src/js/services/uhc-settings.js
+++ b/webapp/src/js/services/uhc-settings.js
@@ -31,9 +31,9 @@ angular.module('inboxServices').factory('UHCSettings',
     };
 
     return {
-      getVisitCountSettings: getVisitCountSettings,
-      getMonthStartDate: getMonthStartDate,
-      getContactsDefaultSort: getContactsDefaultSort
+      getVisitCountSettings,
+      getMonthStartDate,
+      getContactsDefaultSort
     };
   }
 );

--- a/webapp/src/js/services/uhc-settings.js
+++ b/webapp/src/js/services/uhc-settings.js
@@ -1,0 +1,39 @@
+angular.module('inboxServices').factory('UHCSettings',
+  function() {
+    'use strict';
+    'ngInject';
+
+    const getMonthStartDate = settings => {
+      return settings &&
+             settings.uhc &&
+             (
+               settings.uhc.month_start_date ||
+               settings.uhc.visit_count &&
+               settings.uhc.visit_count.month_start_date
+             );
+    };
+
+    const getVisitCountSettings = settings => {
+      if (!settings || !settings.uhc || !settings.uhc.visit_count) {
+        return {};
+      }
+
+      return {
+        monthStartDate: getMonthStartDate(settings),
+        visitCountGoal: settings.uhc.visit_count.visit_count_goal,
+      };
+    };
+
+    const getContactsDefaultSort = settings => {
+      return settings &&
+             settings.uhc &&
+             settings.uhc.contacts_default_sort;
+    };
+
+    return {
+      getVisitCountSettings: getVisitCountSettings,
+      getMonthStartDate: getMonthStartDate,
+      getContactsDefaultSort: getContactsDefaultSort
+    };
+  }
+);

--- a/webapp/tests/karma/unit/services/uhc-settings.js
+++ b/webapp/tests/karma/unit/services/uhc-settings.js
@@ -1,4 +1,4 @@
-describe('TranslationLoader service', function() {
+describe('UHCSettings service', function() {
 
   'use strict';
 
@@ -15,10 +15,10 @@ describe('TranslationLoader service', function() {
 
   describe('getMonthStartDate', () => {
     it('should return falsy for invalid input', () => {
-      chai.expect(service.getMonthStartDate(false)).to.equal(false);
-      chai.expect(service.getMonthStartDate()).to.equal(undefined);
-      chai.expect(service.getMonthStartDate({})).to.equal(undefined);
-      chai.expect(service.getMonthStartDate({ uhc: false })).to.equal(false);
+      chai.expect(!!service.getMonthStartDate(false)).to.equal(false);
+      chai.expect(!!service.getMonthStartDate()).to.equal(false);
+      chai.expect(!!service.getMonthStartDate({})).to.equal(false);
+      chai.expect(!!service.getMonthStartDate({ uhc: false })).to.equal(false);
     });
 
     it('should return correct month_start_date', () => {
@@ -75,10 +75,10 @@ describe('TranslationLoader service', function() {
 
   describe('getContactsDefaultSort', () => {
     it('should return falsy when for invalid input', () => {
-      chai.expect(service.getContactsDefaultSort(false)).to.equal(false);
-      chai.expect(service.getContactsDefaultSort()).to.equal(undefined);
-      chai.expect(service.getContactsDefaultSort({})).to.equal(undefined);
-      chai.expect(service.getContactsDefaultSort({ uhc: false })).to.equal(false);
+      chai.expect(!!service.getContactsDefaultSort(false)).to.equal(false);
+      chai.expect(!!service.getContactsDefaultSort()).to.equal(false);
+      chai.expect(!!service.getContactsDefaultSort({})).to.equal(false);
+      chai.expect(!!service.getContactsDefaultSort({ uhc: false })).to.equal(false);
     });
 
     it('should return correct value', () => {

--- a/webapp/tests/karma/unit/services/uhc-settings.js
+++ b/webapp/tests/karma/unit/services/uhc-settings.js
@@ -1,0 +1,88 @@
+describe('TranslationLoader service', function() {
+
+  'use strict';
+
+  let service;
+
+  beforeEach(function() {
+    module('inboxApp');
+    inject(function($injector) {
+      service = $injector.get('UHCSettings');
+    });
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('getMonthStartDate', () => {
+    it('should return falsy for invalid input', () => {
+      chai.expect(service.getMonthStartDate(false)).to.equal(false);
+      chai.expect(service.getMonthStartDate()).to.equal(undefined);
+      chai.expect(service.getMonthStartDate({})).to.equal(undefined);
+      chai.expect(service.getMonthStartDate({ uhc: false })).to.equal(false);
+    });
+
+    it('should return correct month_start_date', () => {
+      chai.expect(service.getMonthStartDate({ uhc: { month_start_date: 3 }})).to.equal(3);
+      chai.expect(service.getMonthStartDate({ uhc: { month_start_date: 3, visit_count: { month_start_date: 10 } }})).to.equal(3);
+      chai.expect(service.getMonthStartDate({ uhc: { visit_count: { month_start_date: 10 } }})).to.equal(10);
+    });
+  });
+
+  describe('getVisitCountSettings', () => {
+    it('should return empty object for invalid input', () => {
+      chai.expect(service.getVisitCountSettings(false)).to.deep.equal({});
+      chai.expect(service.getVisitCountSettings()).to.deep.equal({});
+      chai.expect(service.getVisitCountSettings({})).to.deep.equal({});
+      chai.expect(service.getVisitCountSettings({ uhc: false })).to.deep.equal({});
+    });
+
+    it('should return correct values', () => {
+      let settings = {
+        uhc: {
+          month_start_date: 10,
+          visit_count: {
+            visit_count_goal: 3
+          }
+        }
+      };
+
+      chai.expect(service.getVisitCountSettings(settings)).to.deep.equal({ monthStartDate: 10, visitCountGoal: 3 });
+
+      settings = {
+        uhc: {
+          visit_count: {
+            visit_count_goal: 3,
+            month_start_date: 10
+          }
+        }
+      };
+
+      chai.expect(service.getVisitCountSettings(settings)).to.deep.equal({ monthStartDate: 10, visitCountGoal: 3 });
+
+      settings = {
+        uhc: {
+          month_start_date: 12,
+          visit_count: {
+            visit_count_goal: 3,
+            month_start_date: 10
+          }
+        }
+      };
+
+      chai.expect(service.getVisitCountSettings(settings)).to.deep.equal({ monthStartDate: 12, visitCountGoal: 3 });
+    });
+  });
+
+  describe('getContactsDefaultSort', () => {
+    it('should return falsy when for invalid input', () => {
+      chai.expect(service.getContactsDefaultSort(false)).to.equal(false);
+      chai.expect(service.getContactsDefaultSort()).to.equal(undefined);
+      chai.expect(service.getContactsDefaultSort({})).to.equal(undefined);
+      chai.expect(service.getContactsDefaultSort({ uhc: false })).to.equal(false);
+    });
+
+    it('should return correct value', () => {
+      chai.expect(service.getContactsDefaultSort({ uhc: { contacts_default_sort: 'default' } })).to.equal('default');
+    });
+  });
+});


### PR DESCRIPTION
# Description

Moves app settings `uhc.visit_count.month_start_date` to `uhc.month_start_date` (old location still checked for backwards compatibility). 
Uses app settings `uhc.month_start_date` calendaristic interval to determine target instance relevance, falls back to calendaristic month if not set. 

medic/medic#5544

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
