### PR TITLE
Added new field visited_date to 2 views

### DIFF
--- a/ddocs/medic-client/views/contacts_by_last_visited/map.js
+++ b/ddocs/medic-client/views/contacts_by_last_visited/map.js
@@ -4,8 +4,10 @@ function(doc) {
       doc.fields &&
       doc.fields.visited_contact_uuid) {
 
+    var visited_date = doc.fields.visited_date ? Date.parse(doc.fields.visited_date) : doc.reported_date;
+
     // Is a visit report about a family
-    emit(doc.fields.visited_contact_uuid, doc.reported_date);
+    emit(doc.fields.visited_contact_uuid, visited_date);
   } else if (doc.type === 'clinic') {
     // Is a family
     emit(doc._id, 0);

--- a/ddocs/medic-client/views/visits_by_date/map.js
+++ b/ddocs/medic-client/views/visits_by_date/map.js
@@ -4,7 +4,9 @@ function(doc) {
       doc.fields &&
       doc.fields.visited_contact_uuid) {
 
+    var visited_date = doc.fields.visited_date ? Date.parse(doc.fields.visited_date) : doc.reported_date;
+
     // Is a visit report about a family
-    emit(doc.reported_date, doc.fields.visited_contact_uuid);
+    emit(visited_date, doc.fields.visited_contact_uuid);
   }
 }


### PR DESCRIPTION
# Description

If the report has a field visited_date, it will be used to determine the visit date. If it does not exist, reported_date will be used.

medic/medic#5579

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
