### PR TITLE
Moves the publish step into CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
   global:
     - COUCH_URL=http://admin:pass@localhost:5984/medic-test
     - COUCH_NODE_NAME=nonode@nohost
-    - BUILDS_SERVER=_couch/builds_testing
-    - STAGING_SERVER=_couch/builds
+    - BUILDS_SERVER=_couch/builds_testing_FAIL
+    - STAGING_SERVER=_couch/builds_FAIL
     # AWS Access Key Id and AWS Secret Access Key encrypted by travis to access the S3 buckets where reports and screenshots are saved
     - secure: TR1UN2r3beDtIF+VJpLF2ocTv/uxuOKyVWWhzMLre0ZrrBaIP1sLZV7Z4S/km5M92EfPgGW87BogdWE/R+kTTRiPTCbFB/U/3jFKxEZRXKST66YK5JMwsYqb17UtZtFdqEtO9GGbAVzXwpZfMMoXvlKNrors2W32xBm2uIkOSpI=
     - secure: Q8RH65NClRBryxfvlwHQjeR4wGs+GXeUBRIBd1kspAM7Uv+5K3iP+q/TPCIrTL/OpJ5tyCYfeq5hKIFFwrY3JikNXnyHICOjXPE6zSLUm8E8NHaP/orPNWjze2x4yDSRCifqzr2ZiXVq9sxlZfNbZ9eyJxpPFTYDSpuN9T5UEE0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,8 @@ jobs:
         - mkdir tests/logs
       script:
         - node --stack_size=10000 `which grunt` ci-compile
-      after_failure: # overwrite default
-      after_success:
         - node --stack_size=10000 `which grunt` publish-for-testing
+      after_failure: # overwrite default
     - stage: publish
       if: type != pull_request
       env: NODE_VERSION=10

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
   global:
     - COUCH_URL=http://admin:pass@localhost:5984/medic-test
     - COUCH_NODE_NAME=nonode@nohost
-    - BUILDS_SERVER=_couch/builds_testing_FAIL
-    - STAGING_SERVER=_couch/builds_FAIL
+    - BUILDS_SERVER=_couch/builds_testing
+    - STAGING_SERVER=_couch/builds
     # AWS Access Key Id and AWS Secret Access Key encrypted by travis to access the S3 buckets where reports and screenshots are saved
     - secure: TR1UN2r3beDtIF+VJpLF2ocTv/uxuOKyVWWhzMLre0ZrrBaIP1sLZV7Z4S/km5M92EfPgGW87BogdWE/R+kTTRiPTCbFB/U/3jFKxEZRXKST66YK5JMwsYqb17UtZtFdqEtO9GGbAVzXwpZfMMoXvlKNrors2W32xBm2uIkOSpI=
     - secure: Q8RH65NClRBryxfvlwHQjeR4wGs+GXeUBRIBd1kspAM7Uv+5K3iP+q/TPCIrTL/OpJ5tyCYfeq5hKIFFwrY3JikNXnyHICOjXPE6zSLUm8E8NHaP/orPNWjze2x4yDSRCifqzr2ZiXVq9sxlZfNbZ9eyJxpPFTYDSpuN9T5UEE0=


### PR DESCRIPTION
# Description

Apparently errors in the `after_success` section don't fail the build. This causes the subsequent jobs to fail with a misleading error ("failed to start API"). Moving it into the `script` section causes the `compile` job to fail so it fails earlier and in a way that's easier to debug.

medic/medic#5196

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
