### PR TITLE
Cannot log in as offline user: Failed to execute 'respondWith' on 'FetchEvent'

### DIFF
--- a/grunt/service-worker.tmpl
+++ b/grunt/service-worker.tmpl
@@ -133,7 +133,7 @@ self.addEventListener('fetch', function(event) {
     // But it fails when running e2e test
     // this has been attributed by the root url serving both json GET request and the cached HTML page
     if (event.request.headers.get('accept').indexOf('application/json') !== -1) {
-      event.respondWith(async function() {
+      return event.respondWith(async function() {
         return fetch(event.request);
       }());
     }

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -143,7 +143,7 @@ _.templateSettings = {
 
   // Detects reloads or route updates (#/something)
   angular.module('inboxApp').run(function($state, $transitions, Auth) {
-    $transitions.onStart({}, function(trans) {
+    $transitions.onBefore({}, function(trans) {
       if (trans.to().name.indexOf('error') === -1) {
         const permissions = getRequiredPermissions(trans.to().name);
         if (permissions && permissions.length) {

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -143,7 +143,7 @@ _.templateSettings = {
 
   // Detects reloads or route updates (#/something)
   angular.module('inboxApp').run(function($state, $transitions, Auth) {
-    $transitions.onBefore({}, function(trans) {
+    $transitions.onStart({}, function(trans) {
       if (trans.to().name.indexOf('error') === -1) {
         const permissions = getRequiredPermissions(trans.to().name);
         if (permissions && permissions.length) {


### PR DESCRIPTION
# Description

Broken experience after merging #5448. I can no longer log in as an offline user. Due to

```Uncaught (in promise) DOMException: Failed to execute 'respondWith' on 'FetchEvent': The fetch event has already been responded to```

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
