### PR TITLE
6042 fix case sensitive issue

### DIFF
--- a/config/standard/contact-summary-extras.js
+++ b/config/standard/contact-summary-extras.js
@@ -259,7 +259,7 @@ var addImmunizations = function(master, vaccines_received) {
     if(!master[dose[0]]) {
       master[dose[0]] = typeof vaccines_received === 'string' ?
           vaccines_received.toUpperCase() === dose[1] :
-          vaccines_received['received_' + dose[0]] === 'yes';
+          vaccines_received['received_' + dose[0]].toLowerCase() === 'yes';
     }
   });
 };


### PR DESCRIPTION
# Description
The immunization visit form (form: C_IMM) submitted from collect app has value `Yes` for a immunization received, i.e. `"received_bcg": "Yes"`. In the code, `addImmunizations(): vaccines_received['received_' + dose[0]] === 'yes'` checks for `yes`. And, since `Yes` and `yes` are different in case, the condition card is not getting updated for the immunization visit forms submitted from the collect app. To overcome this case-sensitive issue, `toLowerCase()` is used in the comparison in the relevant function. It is related to [GH Issue 6402](https://github.com/medic/medic-projects/issues/6042#issuecomment-483633418).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
