### PR TITLE
Alleviate performance issue related to report tab

### DIFF
--- a/webapp/src/js/controllers/analytics-reporting-detail.js
+++ b/webapp/src/js/controllers/analytics-reporting-detail.js
@@ -12,6 +12,7 @@ angular.module('inboxControllers').controller('AnalyticsReportingDetailCtrl',
     ChildFacility,
     DB,
     FormatDataRecord,
+    PlaceHierarchy,
     Settings
   ) {
 
@@ -20,6 +21,7 @@ angular.module('inboxControllers').controller('AnalyticsReportingDetailCtrl',
 
     $scope.filters.form = $state.params.form;
     $scope.filters.place = $state.params.place;
+    $scope.facilities = [];
 
     Settings()
       .then(function(settings) {
@@ -217,6 +219,17 @@ angular.module('inboxControllers').controller('AnalyticsReportingDetailCtrl',
     };
 
     setDistrict($state.params.place);
+
+    var loadAvailableFacilities = function() {
+      PlaceHierarchy()
+        .then(function(hierarchy) {
+          $scope.facilities = hierarchy;
+        })
+        .catch(function(err) {
+          $log.error('Error loading facilities', err);
+        });
+    };
+    loadAvailableFacilities();
 
     var getViewReports = function(doc, dates) {
       var params = reportingUtils.getReportingViewArgs(dates),

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -24,7 +24,6 @@ var _ = require('underscore'),
     Auth,
     Changes,
     CheckDate,
-    ContactSchema,
     CountMessages,
     DBSync,
     DatabaseConnectionMonitor,
@@ -36,7 +35,6 @@ var _ = require('underscore'),
     LiveListConfig,
     Location,
     Modal,
-    PlaceHierarchy,
     RecurringProcessManager,
     ResourceIcons,
     RulesEngine,
@@ -213,7 +211,6 @@ var _ = require('underscore'),
     $scope.error = false;
     $scope.errorSyntax = false;
     $scope.appending = false;
-    $scope.facilities = [];
     $scope.people = [];
     $scope.filterQuery = { value: null };
     $scope.version = APP_CONFIG.version;
@@ -376,29 +373,6 @@ var _ = require('underscore'),
       if (!$state.includes('reports')) {
         ctrl.setSelectMode(false);
       }
-    });
-
-    var updateAvailableFacilities = function() {
-      PlaceHierarchy()
-        .then(function(hierarchy) {
-          $scope.facilities = hierarchy;
-        })
-        .catch(function(err) {
-          $log.error('Error loading facilities', err);
-        });
-    };
-    updateAvailableFacilities();
-
-    Changes({
-      key: 'inbox-facilities',
-      filter: function(change) {
-        var hierarchyTypes = ContactSchema.getPlaceTypes().filter(function(pt) {
-          return pt !== 'clinic';
-        });
-        // check if new document is a contact
-        return change.doc && hierarchyTypes.indexOf(change.doc.type) !== -1;
-      },
-      callback: updateAvailableFacilities,
     });
 
     $scope.unreadCount = {};

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -5,6 +5,7 @@ const _ = require('underscore'),
 angular
   .module('inboxControllers')
   .controller('ReportsCtrl', function(
+    $document,
     $log,
     $ngRedux,
     $scope,
@@ -50,6 +51,29 @@ angular
     const unsubscribe = $ngRedux.connect(mapStateToTarget, mapDispatchToTarget)(ctrl);
 
     var lineage = lineageFactory();
+
+    // Load the places hierarchy as the user is scrolling through the list
+    // Initially, don't load/display any
+    $scope.totalFacilitiesDisplayed = 0;
+
+    $scope.monitorFacilityDropdown = () => {
+      $document[0].querySelector('#facilityDropdown')
+                  .addEventListener('click', () => {
+        $scope.$apply(function() {
+          $scope.totalFacilitiesDisplayed += 1;
+        });
+      });
+
+      $document[0].querySelector('#facilityDropdown span.dropdown-menu > ul')
+                  .addEventListener('scroll', (event) => {
+        // visible height + pixel scrolled >= total height 
+        if (event.target.offsetHeight + event.target.scrollTop >= event.target.scrollHeight - 100) {
+          $scope.$apply(function() {
+            $scope.totalFacilitiesDisplayed += 1;
+          });
+        }
+      });
+    };
 
     // selected objects have the form
     //    { _id: 'abc', summary: { ... }, report: { ... }, expanded: false }

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -5,7 +5,6 @@ const _ = require('underscore'),
 angular
   .module('inboxControllers')
   .controller('ReportsCtrl', function(
-    $document,
     $log,
     $ngRedux,
     $scope,
@@ -70,13 +69,10 @@ angular
           $log.error('Error loading facilities', err);
         });
 
-      $document[0].querySelector('#facilityDropdown span.dropdown-menu > ul')
-                  .addEventListener('scroll', (event) => {
+      $('#facilityDropdown span.dropdown-menu > ul').scroll((event) => {
         // visible height + pixel scrolled >= total height - 100
         if (event.target.offsetHeight + event.target.scrollTop >= event.target.scrollHeight - 100) {
-          $scope.$apply(function() {
-            $scope.totalFacilitiesDisplayed += 1;
-          });
+          $timeout(() => $scope.totalFacilitiesDisplayed += 1);
         }
       });
     };

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -459,7 +459,7 @@ angular
         if (!$scope.loading && $scope.moreItems) {
           query({ skip: true });
         }
-      });console.log('start', (new Date).getTime());
+      });
     };
 
     if (!$state.params.id) {

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -22,6 +22,7 @@ angular
     LiveList,
     MarkRead,
     Modal,
+    PlaceHierarchy,
     ReportViewModelGenerator,
     Search,
     SearchFilters,
@@ -52,21 +53,26 @@ angular
 
     var lineage = lineageFactory();
 
-    // Load the places hierarchy as the user is scrolling through the list
-    // Initially, don't load/display any
+    // Render the facilities hierarchy as the user is scrolling through the list
+    // Initially, don't load/render any
     $scope.totalFacilitiesDisplayed = 0;
+    $scope.facilities = [];
 
+    // Load the facilities hierarchy and render one district hospital 
+    // when the user clicks on the filter dropdown
     $scope.monitorFacilityDropdown = () => {
-      $document[0].querySelector('#facilityDropdown')
-                  .addEventListener('click', () => {
-        $scope.$apply(function() {
+      PlaceHierarchy()
+        .then(function(hierarchy) {
+          $scope.facilities = hierarchy;
           $scope.totalFacilitiesDisplayed += 1;
+        })
+        .catch(function(err) {
+          $log.error('Error loading facilities', err);
         });
-      });
 
       $document[0].querySelector('#facilityDropdown span.dropdown-menu > ul')
                   .addEventListener('scroll', (event) => {
-        // visible height + pixel scrolled >= total height 
+        // visible height + pixel scrolled >= total height - 100
         if (event.target.offsetHeight + event.target.scrollTop >= event.target.scrollHeight - 100) {
           $scope.$apply(function() {
             $scope.totalFacilitiesDisplayed += 1;
@@ -453,7 +459,7 @@ angular
         if (!$scope.loading && $scope.moreItems) {
           query({ skip: true });
         }
-      });
+      });console.log('start', (new Date).getTime());
     };
 
     if (!$state.params.id) {

--- a/webapp/src/templates/directives/filters/facility.html
+++ b/webapp/src/templates/directives/filters/facility.html
@@ -9,8 +9,8 @@
     <span class="mm-button-text"></span>
   </span>
   <span role="menu" aria-labelledby="facility" class="dropdown-menu mm-dropdown-menu">
-    <ul>
-      <li role="presentation" ng-repeat="facility in facilities | orderBy:'doc.name'" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = 0"></li>
+    <ul ng-init="monitorFacilityDropdown()">
+      <li role="presentation" ng-repeat="facility in facilities | orderBy:'doc.name' | limitTo:totalFacilitiesDisplayed" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = 0"></li>
     </ul>
   </span>
 </span>

--- a/webapp/src/templates/directives/filters/facility.html
+++ b/webapp/src/templates/directives/filters/facility.html
@@ -11,7 +11,7 @@
   <span role="menu" aria-labelledby="facility" class="dropdown-menu mm-dropdown-menu">
     <div class="loader" ng-show="!facilities.length"></div>
     <ul>
-      <li role="presentation" ng-repeat="facility in facilities | orderBy:'doc.name' | limitTo:totalFacilitiesDisplayed" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = 0"></li>
+      <li role="presentation" ng-repeat="facility in facilities | orderBy:'doc.name' | limitTo:totalFacilitiesDisplayed track by facility.doc._id" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = 0"></li>
     </ul>
   </span>
 </span>

--- a/webapp/src/templates/directives/filters/facility.html
+++ b/webapp/src/templates/directives/filters/facility.html
@@ -1,4 +1,4 @@
-<span id="facilityDropdown" class="filter dropdown mm-dropdown multidropdown" data-label-no-filter="All facilities" data-filter-label="Number of facilities" ng-show="facilities.length && (facilities.length > 1 || facilities[0].children.length)" ng-class="{ 'disabled': $ctrl.selectMode && $ctrl.selected.length }">
+<span id="facilityDropdown" class="filter dropdown mm-dropdown multidropdown" data-label-no-filter="All facilities" data-filter-label="Number of facilities" ng-class="{ 'disabled': $ctrl.selectMode && $ctrl.selected.length }" ng-click="monitorFacilityDropdown()">
   <span id="facility" class="mm-button" data-toggle="dropdown">
     <span class="mm-button-icon">
       <span class="fa fa-hospital-o"></span>
@@ -9,7 +9,8 @@
     <span class="mm-button-text"></span>
   </span>
   <span role="menu" aria-labelledby="facility" class="dropdown-menu mm-dropdown-menu">
-    <ul ng-init="monitorFacilityDropdown()">
+    <div class="loader" ng-show="!facilities.length"></div>
+    <ul>
       <li role="presentation" ng-repeat="facility in facilities | orderBy:'doc.name' | limitTo:totalFacilitiesDisplayed" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = 0"></li>
     </ul>
   </span>

--- a/webapp/src/templates/partials/filters/facility_items.html
+++ b/webapp/src/templates/partials/filters/facility_items.html
@@ -1,4 +1,4 @@
 <a role="menuitem" tabindex="-1" data-value="{{::facility.doc._id}}" class="{{:: 'indent-' + facilityDepth}}">{{::facility.doc.name || ((isAdmin ? 'place.deleted' : 'place.unavailable') | translate)}}</a>
 <ul class="mm-dropdown-submenu">
-  <li role="presentation" ng-repeat="facility in ::facility.children | orderBy:'doc.name'" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = facilityDepth + 1"></li>
+  <li role="presentation" ng-repeat="facility in ::facility.children | orderBy:'doc.name' track by facility.doc._id" ng-include="::'templates/partials/filters/facility_items.html'" ng-init="facilityDepth = facilityDepth + 1"></li>
 </ul>

--- a/webapp/tests/karma/unit/controllers/inbox.js
+++ b/webapp/tests/karma/unit/controllers/inbox.js
@@ -191,8 +191,7 @@ describe('InboxCtrl controller', () => {
     chai.expect(RecurringProcessManager.startUpdateReadDocsCount.callCount).to.equal(1);
   });
 
-  it('should watch changes in facilities, translations, ddoc and user context', () => {
-    chai.expect(changesListener['inbox-facilities']).to.be.an('object');
+  it('should watch changes in translations, ddoc and user context', () => {
     chai.expect(changesListener['inbox-translations']).to.be.an('object');
     chai.expect(changesListener['inbox-ddoc']).to.be.an('object');
     chai.expect(changesListener['inbox-user-context']).to.be.an('object');

--- a/webapp/tests/karma/unit/controllers/reports.js
+++ b/webapp/tests/karma/unit/controllers/reports.js
@@ -12,6 +12,7 @@ describe('ReportsCtrl controller', () => {
       modal,
       LiveList,
       MarkRead,
+      PlaceHierarchy,
       Search,
       Changes,
       FormatDataRecord,
@@ -80,6 +81,7 @@ describe('ReportsCtrl controller', () => {
     };
 
     Search = sinon.stub().resolves();
+    PlaceHierarchy = sinon.stub().resolves([]);
 
     Changes = sinon.stub().callsFake(options => {
       changesCallback = options.callback;

--- a/webapp/tests/karma/unit/controllers/reports.js
+++ b/webapp/tests/karma/unit/controllers/reports.js
@@ -113,6 +113,7 @@ describe('ReportsCtrl controller', () => {
         MarkRead: MarkRead,
         MessageState: {},
         Modal: modal,
+        PlaceHierarchy: PlaceHierarchy,
         ReportViewModelGenerator: {},
         Search: Search,
         SearchFilters: searchFilters,


### PR DESCRIPTION
# Description

With this commit, the report tab will load without the facilities tree filter being built. When the user clicks on the tab, an initial load of the facilities tree takes place. Subsequent load happen as the user is scrolling through the list of facilities hierarchy and reaching the bottom of the list.

medic/medic#4423

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
