### PR TITLE
Add a v3.4.0 "Known Issues" in release notes

### DIFF
--- a/release-notes/docs/3.4.0.md
+++ b/release-notes/docs/3.4.0.md
@@ -6,6 +6,10 @@
 - [Improved performance loading Contacts tab](#improved-performance-loading-contacts-tab)
 - [And more...](#and-more)
 
+## Known issues
+
+- [medic#5617](https://github.com/medic/medic/issues/5617): Users with custom locales are unable to load the contacts tab 
+
 ## Upgrade notes
 
 ### Breaking changes
@@ -131,7 +135,3 @@ We made several changes to reduce the time it takes to load information on the C
 - [medic#5038](https://github.com/medic/medic/issues/5038): Fix flakey test: Reports Summary Displays correct LHS and RHS summary Concerning reports using patient_id
 - [medic#5099](https://github.com/medic/medic/issues/5099): Fix and re-instate flakey e2e test
 - [medic#5227](https://github.com/medic/medic/issues/5227): Clarify process for running e2e tests locally
-
-## Known Issues
-
-- [medic#5617](https://github.com/medic/medic/issues/5617): Users with custom locales are unable to load the contacts tab 

--- a/release-notes/docs/3.4.0.md
+++ b/release-notes/docs/3.4.0.md
@@ -131,3 +131,7 @@ We made several changes to reduce the time it takes to load information on the C
 - [medic#5038](https://github.com/medic/medic/issues/5038): Fix flakey test: Reports Summary Displays correct LHS and RHS summary Concerning reports using patient_id
 - [medic#5099](https://github.com/medic/medic/issues/5099): Fix and re-instate flakey e2e test
 - [medic#5227](https://github.com/medic/medic/issues/5227): Clarify process for running e2e tests locally
+
+## Known Issues
+
+- [medic#5617](https://github.com/medic/medic/issues/5617): Users with custom locales are unable to load the contacts tab 


### PR DESCRIPTION
It would be useful to document significant live-site issues which are likely to impact users who deploy that build. In this case, I'm imagining partners trying to self-host this build; or somebody deploying the latest stable build. Not sure how helpful this would actually be, but it's a starting point.