### PR TITLE
Extract resources to /tmp when NODE_ENV=production

### DIFF
--- a/api/src/resource-extraction.js
+++ b/api/src/resource-extraction.js
@@ -7,9 +7,9 @@ Therefore, we extract all cacheable resources into a folder and serve them as pu
 const
   fs = require('fs'),
   path = require('path'),
+  { env } = require('process'),
   db = require('./db'),
   logger = require('./logger'),
-  STATIC_RESOURCE_DESTINATION = path.join(__dirname, `extracted-resources/`),
   isAttachmentCacheable = name => name === 'manifest.json' || !!name.match(/(?:audio|css|fonts|templates|img|js|xslt)\/.*/);
 
 // Map of attachmentName -> attachmentDigest used to avoid extraction of unchanged documents
@@ -17,22 +17,34 @@ let extractedDigests = {};
 
 const createFolderIfDne = x => !fs.existsSync(x) && fs.mkdirSync(x);
 
+const getDestinationDirectory = () => {
+  let destination = env['MEDIC_API_RESOURCE_PATH'];
+  if (!destination) {
+    const isProduction = env['NODE_ENV'] === 'production';
+    const defaultLocation = path.join(__dirname, `extracted-resources`);
+    destination = isProduction ? '/tmp' : defaultLocation;
+  }
+
+  return path.resolve(destination);
+};
+
 const extractCacheableAttachments = () => {
-  createFolderIfDne(STATIC_RESOURCE_DESTINATION);
+  const extractToDirectory = getDestinationDirectory();
+  createFolderIfDne(extractToDirectory);
   return db.medic
     .get('_design/medic')
     .then(ddoc => Promise.resolve(Object.keys(ddoc._attachments))
       .then(attachmentNames => attachmentNames.filter(name => extractedDigests[name] !== ddoc._attachments[name].digest))
       .then(attachmentNames => attachmentNames.filter(isAttachmentCacheable))
-      .then(requiredNames => Promise.all(requiredNames.map(required => extractAttachment(required))))
+      .then(requiredNames => Promise.all(requiredNames.map(required => extractAttachment(extractToDirectory, required))))
       .then(attachmentNames => attachmentNames.forEach(name => extractedDigests[name] = ddoc._attachments[name].digest))
     );
 };
 
-const extractAttachment = attachmentName => db.medic
+const extractAttachment = (extractToDirectory, attachmentName) => db.medic
   .getAttachment('_design/medic', attachmentName)
   .then(raw => new Promise((resolve, reject) => {
-    const outputPath = path.join(STATIC_RESOURCE_DESTINATION, attachmentName);
+    const outputPath = path.join(extractToDirectory, attachmentName);
     createFolderIfDne(path.dirname(outputPath));
 
     fs.writeFile(outputPath, raw, err => {
@@ -46,5 +58,6 @@ const extractAttachment = attachmentName => db.medic
 
 module.exports = {
   run: extractCacheableAttachments,
+  getDestinationDirectory,
   clearCache: () => extractedDigests = {},
 };

--- a/api/src/resource-extraction.js
+++ b/api/src/resource-extraction.js
@@ -22,7 +22,7 @@ const getDestinationDirectory = () => {
   if (!destination) {
     const isProduction = env['NODE_ENV'] === 'production';
     const defaultLocation = path.join(__dirname, `extracted-resources`);
-    destination = isProduction ? '/tmp' : defaultLocation;
+    destination = isProduction ? '/tmp/extracted-resources' : defaultLocation;
   }
 
   return path.resolve(destination);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -43,7 +43,7 @@ const _ = require('underscore'),
   uuid = require('uuid'),
   compression = require('compression'),
   BUILDS_DB = 'https://staging.dev.medicmobile.org/_couch/builds/', // jshint ignore:line
-  STATIC_RESOURCE_DESTINATION = path.join(__dirname, `extracted-resources/`),
+  extractedResourceDirectory = require('./resource-extraction').getDestinationDirectory(),
   app = express();
 
 // requires content-type application/json header
@@ -171,7 +171,7 @@ app.get('/', function(req, res) {
     // couchdb request - let it go
     proxy.web(req, res);
   } else {
-    res.sendFile(path.join(STATIC_RESOURCE_DESTINATION, 'templates/inbox.html'));
+    res.sendFile(path.join(extractedResourceDirectory, 'templates/inbox.html'));
   }
 });
 
@@ -230,7 +230,7 @@ app.get('/favicon.ico', (req, res) => {
 });
 
 app.use(express.static(path.join(__dirname, '../build/public')));
-app.use(express.static(path.join(__dirname, 'extracted-resources')));
+app.use(express.static(extractedResourceDirectory));
 app.get(routePrefix + 'login', login.get);
 app.get(routePrefix + 'login/identity', login.getIdentity);
 app.postJson(routePrefix + 'login', login.post);
@@ -602,7 +602,7 @@ app.get('/service-worker.js', (req, res) => {
     ['Content-Type', 'application/javascript'],
   ]);
 
-  res.sendFile(path.join(__dirname, 'extracted-resources/js/service-worker.js'));
+  res.sendFile(path.join(extractedResourceDirectory, 'js/service-worker.js'));
 });
 
 // To clear the application cache for users upgrading from legacy clients, serve an empty application manifest

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -1,5 +1,4 @@
 const rewire = require('rewire'),
-      path = require('path'),
       resourceExtraction = rewire('../../src/resource-extraction'),
       sinon = require('sinon'),
       { expect } = require('chai'); // jshint ignore:line

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -1,4 +1,5 @@
 const rewire = require('rewire'),
+      path = require('path'),
       resourceExtraction = rewire('../../src/resource-extraction'),
       sinon = require('sinon'),
       { expect } = require('chai'); // jshint ignore:line
@@ -31,6 +32,21 @@ function doMocking(overwrites = {}) {
 }
 
 describe('Resource Extraction', () => {
+  describe('getDestinationDirectory', () => {
+    const testScenario = (env, expected) => resourceExtraction.__with__({
+      env,
+      __dirname: '/__dirname',
+    })(() => {
+      const actual = resourceExtraction.getDestinationDirectory();
+      expect(actual).to.eq(expected);
+    });
+
+    it('default', () => testScenario({}, '/__dirname/extracted-resources'));
+    it('explicit via env', () => testScenario({ MEDIC_API_RESOURCE_PATH: '/foo' }, '/foo'));
+    it('default in production', () => testScenario({ NODE_ENV: 'production' }, '/tmp'));
+    it('explit and production', () => testScenario({ MEDIC_API_RESOURCE_PATH: '/foo', NODE_ENV: 'production' }, '/foo'));
+  });
+
   it('attachments written to disk', done => {
     const expected = { content: { toString: () => 'foo' } };
     doMocking(expected);

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -42,7 +42,7 @@ describe('Resource Extraction', () => {
 
     it('default', () => testScenario({}, '/__dirname/extracted-resources'));
     it('explicit via env', () => testScenario({ MEDIC_API_RESOURCE_PATH: '/foo' }, '/foo'));
-    it('default in production', () => testScenario({ NODE_ENV: 'production' }, '/tmp'));
+    it('default in production', () => testScenario({ NODE_ENV: 'production' }, '/tmp/extracted-resources'));
     it('explit and production', () => testScenario({ MEDIC_API_RESOURCE_PATH: '/foo', NODE_ENV: 'production' }, '/foo'));
   });
 


### PR DESCRIPTION
# Description

Deploying latest master is crashing inside the docker container due to the permissions of the folder where resources are extracted. This change redirects production resource extraction to `/tmp` when `NODE_ENV=production`.
#5519 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
