### PR TITLE
Requests with Accept: application/json don't work when offline

### DIFF
--- a/grunt/service-worker.tmpl
+++ b/grunt/service-worker.tmpl
@@ -132,7 +132,9 @@ self.addEventListener('fetch', function(event) {
     // if (event.request.method === 'GET' && event.request.headers.get('accept').indexOf('application/json') === -1) {
     // But it fails when running e2e test
     // this has been attributed by the root url serving both json GET request and the cached HTML page
-    if (event.request.headers.get('accept').indexOf('application/json') !== -1) {
+    const isJsonRequest = event.request.headers.get('accept').indexOf('application/json') !== -1;
+    const isRootRequest = new URL(event.request.url).pathname === '/';
+    if (isRootRequest && isJsonRequest) {
       return event.respondWith(async function() {
         return fetch(event.request);
       }());

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "env": {
     "jasmine": true,
     "jquery": true,

--- a/tests/e2e/service-worker.js
+++ b/tests/e2e/service-worker.js
@@ -1,0 +1,103 @@
+const { expect } = require('chai');
+const URL = require('url');
+const utils = require('../utils');
+
+const getCachedRequests = async () => {
+  const cacheDetails = await browser.executeAsyncScript(async () => {
+    const callback = arguments[arguments.length - 1];
+    const cacheNames = await caches.keys()
+    const cache = await caches.open(cacheNames[0]);
+    const cachedRequests = await cache.keys();
+    const cachedRequestSummary = cachedRequests.map(req => ({ url: req.url }));
+    callback({
+      name: cacheNames[0],
+      requests: cachedRequestSummary,
+    });
+  });
+
+  const urls = cacheDetails.requests.map(request => URL.parse(request.url).pathname);
+  urls.sort();
+  return { name: cacheDetails.name, urls };
+};
+
+const stubAllCachedRequests = () => browser.executeAsyncScript(async () => {
+  const callback = arguments[arguments.length - 1];
+  const cacheNames = await caches.keys()
+  const cache = await caches.open(cacheNames[0]);
+  const cachedRequests = await cache.keys();
+  await Promise.all(cachedRequests.map(request => cache.put(request, new Response('cache'))));
+  callback();
+});
+
+const doFetch = (path, headers) => browser.executeAsyncScript(async (innerPath, innerHeaders) => {
+  const callback = arguments[arguments.length - 1];
+  const result = await fetch(innerPath, { headers: innerHeaders });
+  callback({
+    body: await result.text(),
+    ok: result.ok,
+    status: result.status,
+  });
+}, path, headers);
+
+const unregisterServiceWorker = () => browser.executeAsyncScript(async () => {
+  const callback = arguments[arguments.length - 1];
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  registrations.forEach(registration => registration.unregister());
+  callback();
+});
+
+describe('Service worker cache', () => {
+  afterEach(utils.afterEach);
+
+  it('confirm initial list of cached resources', async () => {
+    const cacheDetails = await getCachedRequests();
+    expect(cacheDetails.name.startsWith('sw-precache-v3-cache-')).to.be.true; 
+    expect(cacheDetails.urls).to.deep.eq([
+      '/',
+      '/audio/alert.mp3',
+      '/css/inbox.css',
+      '/img/icon-chw-selected.svg',
+      '/img/icon-chw.svg',
+      '/img/icon-nurse-selected.svg',
+      '/img/icon-nurse.svg',
+      '/img/icon-pregnant-selected.svg',
+      '/img/icon-pregnant.svg',
+      '/img/setup-wizard-demo.png',
+      '/img/simprints.png',
+      '/js/inbox.js',
+      '/js/templates.js',
+      '/manifest.json',
+      '/xslt/openrosa2html5form.xsl',
+      '/xslt/openrosa2xmlmodel.xsl',
+    ]);
+  });
+
+  it('confirm fetch yields cached result', async () => {
+    const expectCachedState = async (expectCached, path, headers = {}) => {
+      const result = await doFetch(path, headers);
+      expect(result.body === 'cache').to.eq(expectCached, path);
+    };
+
+    try {
+      const { urls: initialCachedUrls } = await getCachedRequests();
+      await stubAllCachedRequests();
+
+      await expectCachedState(true, '/');
+      await expectCachedState(true, '/', { 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3' });
+      
+      await expectCachedState(true, '/xslt/openrosa2xmlmodel.xsl');
+      await expectCachedState(true, '/xslt/openrosa2xmlmodel.xsl', { 'Accept': 'application/json, text/plain, */*' });
+
+      // no part of syncing is cached
+      await expectCachedState(false, '/', { 'Accept': 'application/json' });
+      await expectCachedState(false, '/medic/_changes?style=all_docs&limit=100');
+      
+      // confirm no additional requests were added into the cache
+      const { urls: resultingCachedUrls } = await getCachedRequests();
+      expect(resultingCachedUrls).to.deep.eq(initialCachedUrls);
+    } finally {
+      // since we've broken the cache. for sw registration
+      await unregisterServiceWorker();
+    }
+  });
+});

--- a/tests/e2e/service-worker.js
+++ b/tests/e2e/service-worker.js
@@ -53,11 +53,15 @@ describe('Service worker cache', () => {
 
   it('confirm initial list of cached resources', async () => {
     const cacheDetails = await getCachedRequests();
-    expect(cacheDetails.name.startsWith('sw-precache-v3-cache-')).to.be.true; 
+    expect(cacheDetails.name.startsWith('sw-precache-v3-cache-')).to.be.true;
     expect(cacheDetails.urls).to.deep.eq([
       '/',
       '/audio/alert.mp3',
       '/css/inbox.css',
+      '/fonts/NotoSans-Bold.ttf',
+      '/fonts/NotoSans-Regular.ttf',
+      '/fonts/enketo-icons-v2.woff',
+      '/fonts/fontawesome-webfont.woff2',
       '/img/icon-chw-selected.svg',
       '/img/icon-chw.svg',
       '/img/icon-nurse-selected.svg',
@@ -68,7 +72,10 @@ describe('Service worker cache', () => {
       '/img/simprints.png',
       '/js/inbox.js',
       '/js/templates.js',
+      '/login/script.js',
+      '/login/style.css',
       '/manifest.json',
+      '/medic/login',
       '/xslt/openrosa2html5form.xsl',
       '/xslt/openrosa2xmlmodel.xsl',
     ]);

--- a/tests/e2e/service-worker.js
+++ b/tests/e2e/service-worker.js
@@ -2,10 +2,12 @@ const { expect } = require('chai');
 const URL = require('url');
 const utils = require('../utils');
 
+/* global caches fetch Response navigator */
+
 const getCachedRequests = async () => {
   const cacheDetails = await browser.executeAsyncScript(async () => {
     const callback = arguments[arguments.length - 1];
-    const cacheNames = await caches.keys()
+    const cacheNames = await caches.keys();
     const cache = await caches.open(cacheNames[0]);
     const cachedRequests = await cache.keys();
     const cachedRequestSummary = cachedRequests.map(req => ({ url: req.url }));
@@ -22,7 +24,7 @@ const getCachedRequests = async () => {
 
 const stubAllCachedRequests = () => browser.executeAsyncScript(async () => {
   const callback = arguments[arguments.length - 1];
-  const cacheNames = await caches.keys()
+  const cacheNames = await caches.keys();
   const cache = await caches.open(cacheNames[0]);
   const cachedRequests = await cache.keys();
   await Promise.all(cachedRequests.map(request => cache.put(request, new Response('cache'))));


### PR DESCRIPTION
# Description

Any request with an `Accept: application/json` header will not be served from service worker's cache.
#5621

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
