### PR TITLE
Adding instructions on using ngrok to access your local dev environment. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,11 @@ This process is relevant for viewing the Medic webapp on mobile devices when the
 1. Create an ngrok account at https://ngrok.com/ 
 2. Follow instructions on downloading and linking your account.
 3. Start the webapp. This can be via docker, grunt, debug, horti, etc....
-3. Run ngrok and forward it towards the port you are running the webapp on. </br>
-  EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok https 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>
-  EX: For runnning via horti, debug, or grunt where the api starts on port 5988. `$ ./ngrok https 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine. 
-
-  The url looks like this. </br> 
-  Forwarding                    http://1661304e.ngrok.io -> http://localhost:5988                                        
-Forwarding                    https://1661304e.ngrok.io -> http://localhost:5988    
+3. Run ngrok and forward it towards the port you are running the webapp on.
+  * EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok https 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>
+  * EX: For runnning via horti, debug, or grunt where the api starts on port 5988. `$ ./ngrok https 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine. 
+3. You can then enter the url into our android app or browser and connect to your local dev environment.                
+* Example output from ngrok: Forwarding https://1661304e.ngrok.io -> http://localhost:5988    
 
 ### Data
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Navigate your browser to [`http://localhost:5988/medic/login`](http://localhost:
 This process is relevant for viewing the Medic webapp on mobile devices when the api service is run on a developer machine running Webapp >v3.5.0. Webapp v3.5.0 relies on service workers, which require a valid HTTPS certificate to function. Follow these steps to make your developer build accessible from your android device at the trusted url created by ngrok.
 
 1. Create an ngrok account at https://ngrok.com/ 
-2. Follow instructions on downloading and linking your account.
+2. Follow instructions on downloading and linking your computer to your ngrok account.
 3. Start the webapp. This can be via docker, grunt, debug, horti, etc....
 3. Run ngrok and forward it towards the port you are running the webapp on.
   * EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok https 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>

--- a/README.md
+++ b/README.md
@@ -142,18 +142,19 @@ Then run either `node ./server.js` from the api directory or `grunt dev-api` fro
 
 Navigate your browser to [`http://localhost:5988/medic/login`](http://localhost:5988/medic/login).
 
-### Working on local environment with real devices. 
+### Working on local environment with real devices 
 
 This process is relevant for viewing the Medic webapp on mobile devices when the api service is run on a developer machine running Webapp >v3.5.0. Webapp v3.5.0 relies on service workers, which require a valid HTTPS certificate to function. Follow these steps to make your developer build accessible from your android device at the trusted url created by ngrok.
 
 1. Create an ngrok account at https://ngrok.com/ 
-2. Follow instructions on downloading and linking your computer to your ngrok account.
-3. Start the webapp. This can be via docker, grunt, debug, horti, etc....
-3. Run ngrok and forward it towards the port you are running the webapp on.
-  * EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok https 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>
-  * EX: For runnning via horti, debug, or grunt where the api starts on port 5988. `$ ./ngrok https 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine. 
-3. You can then enter the url into our android app or browser and connect to your local dev environment.                
-* Example output from ngrok: Forwarding https://1661304e.ngrok.io -> http://localhost:5988    
+1. Follow instructions on downloading and linking your computer to your ngrok account.
+1. Start the webapp. This can be via docker, grunt, debug, horti, etc....
+1. Run ngrok and forward it towards the port you are running the webapp on.
+    * EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok http 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>
+    * EX: For runnning via horti, debug, or grunt where the api starts on port 5988. `$ ./ngrok http 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine.
+    * Example output from ngrok: Forwarding https://1661304e.ngrok.io -> http://localhost:5988 
+1. You can then enter the url(https://1661304e.ngrok.io) into our android app or browser and connect to your local dev environment.                
+
 
 ### Data
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ This process is relevant for viewing the Medic webapp on mobile devices when the
 1. Start the webapp. This can be via docker, grunt, debug, horti, etc....
 1. Run ngrok and forward it towards the port you are running the webapp on.
     * EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok http 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>
-    * EX: For runnning via horti, debug, or grunt where the api starts on port 5988. `$ ./ngrok http 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine.
+    * EX: For running via horti, or grunt where the api starts on port 5988. `$ ./ngrok http 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine.
     * Example output from ngrok: Forwarding https://1661304e.ngrok.io -> http://localhost:5988 
-1. You can then enter the url(https://1661304e.ngrok.io) into our android app or browser and connect to your local dev environment.                
+1. You can then enter the ngrok generated url(https://1661304e.ngrok.io) into our [android app](https://github.com/medic/medic-android) or browser and connect to your local dev environment.                
 
 
 ### Data

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Navigate your browser to [`http://localhost:5988/medic/login`](http://localhost:
 
 This process is relevant for viewing the Medic webapp on mobile devices when the api service is run on a developer machine running Webapp >v3.5.0. Webapp v3.5.0 relies on service workers, which require a valid HTTPS certificate to function. Follow these steps to make your developer build accessible from your android device at the trusted url created by ngrok.
 
-1. Create an ngrok account
+1. Create an ngrok account at https://ngrok.com/ 
 2. Follow instructions on downloading and linking your account.
 3. Start the webapp. This can be via docker, grunt, debug, horti, etc....
 3. Run ngrok and forward it towards the port you are running the webapp on. </br>

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ Then run either `node ./server.js` from the api directory or `grunt dev-api` fro
 
 Navigate your browser to [`http://localhost:5988/medic/login`](http://localhost:5988/medic/login).
 
+### Working on local environment with real devices. 
+
+This process is relevant for viewing the Medic webapp on mobile devices when the api service is run on a developer machine running Webapp >v3.5.0. Webapp v3.5.0 relies on service workers, which require a valid HTTPS certificate to function. Follow these steps to make your developer build accessible from your android device at the trusted url created by ngrok.
+
+1. Create an ngrok account
+2. Follow instructions on downloading and linking your account.
+3. Start the webapp. This can be via docker, grunt, debug, horti, etc....
+3. Run ngrok and forward it towards the port you are running the webapp on. </br>
+  EX: For running webapp in docker locally using the docker instructions above `$ ./ngrok https 443`. This will forward the traffic from your ngrok url on https to 443 on your local machine. </br>
+  EX: For runnning via horti, debug, or grunt where the api starts on port 5988. `$ ./ngrok https 5988` This will forward the traffic from your ngrok url on https to 5988 on your local machine. 
+
+  The url looks like this. </br> 
+  Forwarding                    http://1661304e.ngrok.io -> http://localhost:5988                                        
+Forwarding                    https://1661304e.ngrok.io -> http://localhost:5988    
+
 ### Data
 
 To fill your app with generated data, you can batch-load messages from a CSV file, with the [load_messages.js](https://github.com/medic/medic/blob/master/scripts/load_messages.js) script.


### PR DESCRIPTION
# Description

Added steps that detail creating, downloading, and registering your ngrok account to your computer. 
Then starting the webapp and running ngrok to expose the port you're running on. So you can access your local environment on another device. This is a work around for service workers requiring a https site. 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
