### PR TITLE
Making JSON-inputed JSON forms more flexible

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -391,7 +391,7 @@ GET /api/v1/forms/NPYY.json
 
 ## POST /api/v2/records
 
-Create a new record based on a form. This requires a form definition exists on the server side matching the form code.
+Create a new record based on a [JSON form](https://github.com/medic/medic-docs/blob/master/configuration/forms.md#json-forms) that has been configured.
 
 Records can be created one of two ways, parsing the form data yourself and submitting a JSON object or by submitting the raw message string.
 
@@ -422,7 +422,7 @@ All property names will be lowercased.
 | Key                  | Description                                                                                        |
 | -------------------- | -------------------------------------------------------------------------------------------------- |
 | \_meta.form          | The form code.                                                                                     |
-| \_meta.from          | Reporting phone number.                                                                            |
+| \_meta.from          | Reporting phone number. Optional.                                                                  |
 | \_meta.reported_date | Timestamp in MS since Unix Epoch of when the message was received on the gateway. Defaults to now. |
 | \_meta.locale        | Optional locale string. Example: 'fr'                                                              |
 

--- a/api/src/controllers/records.js
+++ b/api/src/controllers/records.js
@@ -1,6 +1,6 @@
 const auth = require('../auth'),
       serverUtils = require('../server-utils'),
-      recordUtils = require('./record-utils'),
+      records = require('../services/records'),
       config = require('../config');
 
 const runTransitions = doc => {
@@ -11,10 +11,10 @@ const runTransitions = doc => {
 
 const generate = (req, options) => {
   if (req.is('urlencoded')) {
-    return recordUtils.createByForm(req.body, options);
+    return records.createByForm(req.body, options);
   }
   if (req.is('json')) {
-    return recordUtils.createRecordByJSON(req.body);
+    return records.createRecordByJSON(req.body);
   }
   throw new Error('Content type not supported.');
 };

--- a/api/src/controllers/sms-gateway.js
+++ b/api/src/controllers/sms-gateway.js
@@ -4,7 +4,7 @@
  */
 const db = require('../db'),
       messageUtils = require('../message-utils'),
-      recordUtils = require('./record-utils'),
+      records = require('../services/records'),
       logger = require('../logger'),
       config = require('../config'),
       // map from the medic-gateway state to the medic app's state
@@ -93,7 +93,7 @@ const addNewMessages = req => {
         return true;
       }
     }))
-    .then(messages => messages.map(message => recordUtils.createByForm({
+    .then(messages => messages.map(message => records.createByForm({
       from: message.from,
       message: message.content,
       gateway_ref: message.id,

--- a/api/src/services/records.js
+++ b/api/src/services/records.js
@@ -49,6 +49,7 @@ const addError = (record, error) => {
 
   if (!error.message) {
     error.message = config.translate(error.code, getLocale(record), error.ctx);
+    delete error.ctx;
   }
 
   if (!record.errors) {

--- a/api/src/services/records.js
+++ b/api/src/services/records.js
@@ -221,10 +221,16 @@ const createRecordByJSON = data => {
 
   const correctedData = {};
   Object.keys(data).forEach(k => {
-    if (formDefinition.fields[k]  && formDefinition.fields[k].type === 'date') {
-      // Of the data types we support, date is the only one that can't be natively supported in
-      // JSON. Convert it the same way smsparser does, into ms ts
-      data[k] = moment(data[k]).valueOf();
+    if (formDefinition.fields[k]) {
+      if (formDefinition.fields[k].type === 'date') {
+        // Of the data types we support, date is the only one that can't be natively supported in
+        // JSON. Convert it the same way smsparser does, into ms ts
+        data[k] = moment(data[k]).valueOf();
+      } else if (formDefinition.fields[k].type === 'boolean' && [1, 0].includes(data[k])) {
+        // Since in SMS we convert 1 and 0 into true and false we're going to do it here as well for
+        // consistency
+        data[k] = !!data[k];
+      }
     }
 
     correctedData[k.toLowerCase()] = data[k];

--- a/api/src/services/records.js
+++ b/api/src/services/records.js
@@ -1,8 +1,8 @@
 const moment = require('moment'),
       phoneNumber = require('@medic/phone-number'),
       config = require('../config'),
-      smsparser = require('../services/report/smsparser'),
-      validate = require('../services/report/validate'),
+      smsparser = require('./report/smsparser'),
+      validate = require('./report/validate'),
       PublicError = require('../public-error'),
       DATE_NUMBER_STRING = /(\d{13,})/;
 

--- a/api/src/services/report/smsparser.js
+++ b/api/src/services/report/smsparser.js
@@ -138,10 +138,6 @@ const lower = str => (str && str.toLowerCase ? str.toLowerCase() : str);
 exports.parseField = (field, raw) => {
   switch (field.type) {
     case 'integer':
-      // keep months integers, not their list value.
-      if (field.validations && field.validations.is_numeric_month === true) {
-        return parseNum(raw);
-      }
       // store list value since it has more meaning.
       // TODO we don't have locale data inside this function so calling
       // translate does not resolve locale.

--- a/api/src/services/report/textforms-parser.js
+++ b/api/src/services/report/textforms-parser.js
@@ -256,8 +256,8 @@ exports.isCompact = (def, msg, locale) => {
   }
   const labels = _.flatten(_.map(_.values(def.fields), field => {
     return [
-      config.translate(field.labels.tiny, locale),
-      config.translate(field.labels.short, locale)
+      config.translate(field.labels && field.labels.tiny, locale),
+      config.translate(field.labels && field.labels.short, locale)
     ];
   }));
   return !_.some(labels, label => startsWith(fields[0], label));

--- a/api/tests/form-definitions.js
+++ b/api/tests/form-definitions.js
@@ -24,9 +24,6 @@ exports.forms = {
           tiny: 'RPY'
         },
         type: 'integer',
-        validate: {
-          is_numeric_year: true
-        },
         required: true
       },
       month: {
@@ -35,9 +32,6 @@ exports.forms = {
           tiny: 'RPM'
         },
         type: 'integer',
-        validations: {
-          is_numeric_month: true
-        },
         list: [
           [
             1,
@@ -213,9 +207,7 @@ exports.forms = {
         type: 'integer'
       }
     },
-    autoreply: 'Zikomo!',
-    facility_reference: 'facility_id',
-    messages_task: 'function() {var msg = [], ignore = [], dh_ph = clinic && clinic.parent && clinic.parent.parent && clinic.parent.parent.contact && clinic.parent.parent.contact.phone; keys.forEach(function(key) { if (ignore.indexOf(key) === -1) { msg.push(labels.shift() + \': \' + values.shift()); } else { labels.shift(); values.shift(); } }); return {to:dh_ph, message:msg.join(\', \')}; }'
+    facility_reference: 'facility_id'
   },
   YYYZ: {
     meta: {
@@ -344,12 +336,6 @@ exports.forms = {
           4,
           4
         ],
-        validations: {
-          is_numeric_year: true
-        },
-        flags: {
-
-        }
       },
       cref_month: {
         labels: {
@@ -365,9 +351,6 @@ exports.forms = {
           1,
           2
         ],
-        validations: {
-          is_numeric_month: true
-        },
         flags: {
 
         },
@@ -460,9 +443,6 @@ exports.forms = {
           1,
           2
         ],
-        validations: {
-          is_numeric_day: true
-        },
         flags: {
 
         }
@@ -481,9 +461,6 @@ exports.forms = {
           11,
           11
         ],
-        validations: {
-
-        },
         flags: {
           input_digits_only: true
         }
@@ -502,12 +479,6 @@ exports.forms = {
           1,
           2
         ],
-        validations: {
-
-        },
-        flags: {
-
-        },
         list: [
           [
             1,
@@ -554,13 +525,7 @@ exports.forms = {
         length: [
           0,
           20
-        ],
-        validations: {
-
-        },
-        flags: {
-
-        }
+        ]
       },
       cref_age: {
         labels: {
@@ -575,13 +540,7 @@ exports.forms = {
         length: [
           1,
           2
-        ],
-        validations: {
-
-        },
-        flags: {
-
-        }
+        ]
       },
       cref_mom: {
         labels: {
@@ -596,13 +555,7 @@ exports.forms = {
         length: [
           0,
           20
-        ],
-        validations: {
-
-        },
-        flags: {
-
-        }
+        ]
       },
       cref_treated: {
         labels: {
@@ -617,13 +570,7 @@ exports.forms = {
         length: [
           0,
           20
-        ],
-        validations: {
-
-        },
-        flags: {
-
-        }
+        ]
       },
       cref_rec: {
         labels: {
@@ -639,12 +586,6 @@ exports.forms = {
           1,
           2
         ],
-        validations: {
-
-        },
-        flags: {
-
-        },
         list: [
           [
             1,
@@ -727,13 +668,7 @@ exports.forms = {
         length: [
           0,
           35
-        ],
-        validations: {
-
-        },
-        flags: {
-
-        }
+        ]
       },
       cref_agent: {
         labels: {
@@ -748,13 +683,7 @@ exports.forms = {
         length: [
           0,
           20
-        ],
-        validations: {
-
-        },
-        flags: {
-
-        }
+        ]
       }
     },
     facility_reference: 'cref_rc'

--- a/api/tests/mocha/controllers/record-utils-parser.spec.js
+++ b/api/tests/mocha/controllers/record-utils-parser.spec.js
@@ -10,14 +10,14 @@ describe('record-utils-parser', () => {
     sinon.restore();
   });
 
-  it('assert month is parsed as integer', () => {
+  it('assert month is parsed into a string using a list', () => {
     sinon.stub(config, 'get').returns(definitions.forms);
     const body = {
       from: '+888',
       message: '1!YYYY!facility#2011#11'
     };
     const doc = recordUtils.createByForm(body);
-    chai.expect(11).to.equal(doc.fields.month);
+    chai.expect('November').to.equal(doc.fields.month);
   });
 
   it('assert unix timestamp parsed', () => {
@@ -77,17 +77,6 @@ describe('record-utils-parser', () => {
       message:'1!YYYZ!foo#bar'
     };
     const doc = recordUtils.createByForm(body);
-    chai.expect(doc.errors.length).to.equal(0);
-  });
-
-  it('autoreply on YYYY form is ignored', () => {
-    sinon.stub(config, 'get').returns(definitions.forms);
-    const body = {
-      from:'+888',
-      message:'1!YYYY!facility#2012#4#1#222#333#444#555#666#777#888#999#111#222#333#444'
-    };
-    const doc = recordUtils.createByForm(body);
-    chai.expect(doc.form).to.equal('YYYY');
     chai.expect(doc.errors.length).to.equal(0);
   });
 
@@ -232,7 +221,7 @@ describe('record-utils-parser', () => {
     };
     const doc = recordUtils.createByForm(body);
     chai.expect(doc.errors[0].code).to.equal('sys.missing_fields');
-    chai.expect(doc.errors[0].fields).to.deep.equal(['year','month']);
+    chai.expect(doc.errors[0].ctx.fields).to.deep.equal(['year','month']);
   });
 
   it('support unstructured message', () => {

--- a/api/tests/mocha/controllers/sms-gateway.spec.js
+++ b/api/tests/mocha/controllers/sms-gateway.spec.js
@@ -1,7 +1,7 @@
 const chai = require('chai'),
       controller = require('../../../src/controllers/sms-gateway'),
       messageUtils = require('../../../src/message-utils'),
-      recordUtils = require('../../../src/controllers/record-utils'),
+      records = require('../../../src/services/records'),
       db = require('../../../src/db'),
       config = require('../../../src/config'),
       sinon = require('sinon');
@@ -22,7 +22,7 @@ describe('sms-gateway controller', () => {
 
   it('post() should save WT messages to DB', () => {
     // given
-    const createRecord = sinon.stub(recordUtils, 'createByForm')
+    const createRecord = sinon.stub(records, 'createByForm')
       .onCall(0).returns({ message: 'one' })
       .onCall(1).returns({ message: 'two' })
       .onCall(2).returns({ message: 'three' });
@@ -152,7 +152,7 @@ describe('sms-gateway controller', () => {
   });
 
   it('post() returns err if something goes wrong', () => {
-    sinon.stub(recordUtils, 'createByForm')
+    sinon.stub(records, 'createByForm')
       .onCall(0).returns({ message: 'one' });
     sinon.stub(db.medic, 'bulkDocs').returns(Promise.reject(new Error('oh no!')));
     sinon.stub(db.medic, 'query')

--- a/api/tests/mocha/services/record-parser.spec.js
+++ b/api/tests/mocha/services/record-parser.spec.js
@@ -2,9 +2,9 @@ const sinon = require('sinon'),
       chai = require('chai'),
       definitions = require('../../form-definitions'),
       config = require('../../../src/config'),
-      recordUtils = require('../../../src/controllers/record-utils');
+      records = require('../../../src/services/records');
 
-describe('record-utils-parser', () => {
+describe('record parser', () => {
 
   afterEach(() => {
     sinon.restore();
@@ -16,7 +16,7 @@ describe('record-utils-parser', () => {
       from: '+888',
       message: '1!YYYY!facility#2011#11'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect('November').to.equal(doc.fields.month);
   });
 
@@ -26,7 +26,7 @@ describe('record-utils-parser', () => {
       message: 'foo',
       sent_timestamp:'1352499725000'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(new Date(doc.reported_date).toUTCString())
       .to.equal('Fri, 09 Nov 2012 22:22:05 GMT');
   });
@@ -54,7 +54,7 @@ describe('record-utils-parser', () => {
       ors: 5,
       zinc: 4
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.fields.days_stocked_out).to.deep.equal(days_stocked_out);
     chai.expect(doc.fields.quantity_dispensed).to.deep.equal(quantity_dispensed);
   });
@@ -65,7 +65,7 @@ describe('record-utils-parser', () => {
       from: '+13125551212',
       message: '1!YYYY!facility#2011#11#0#1#2#3#4#5#6#9#8#7#6#5#4'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.sms_message.message).to.equal(body.message);
     chai.expect(doc.sms_message.from).to.equal(body.from);
   });
@@ -76,7 +76,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message:'1!YYYZ!foo#bar'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors.length).to.equal(0);
   });
 
@@ -85,7 +85,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message:'foo bar baz'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors.length).to.equal(0);
   });
 
@@ -97,7 +97,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message:'foo bar baz'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors[0].code).to.equal('sys.form_not_found');
     chai.expect(doc.errors.length).to.equal(1);
   });
@@ -108,7 +108,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message: '1!0000!2012#2#20#foo#bar'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors.length).to.equal(0);
   });
 
@@ -121,7 +121,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message: '1!0000!2012#2#20#foo#bar'
     };
-    const doc = recordUtils.createByForm(body, { locale: 'fr' });
+    const doc = records.createByForm(body, { locale: 'fr' });
     chai.expect(doc.errors[0].code).to.equal('sys.form_not_found');
     chai.expect(doc.errors[0].message).to.equal('translated');
     chai.expect(doc.errors.length).to.equal(1);
@@ -140,7 +140,7 @@ describe('record-utils-parser', () => {
       from: '+888',
       message: '1!0000!2012#2#20#foo#bar'
     };
-    recordUtils.createByForm(body, { locale: 'fr' });
+    records.createByForm(body, { locale: 'fr' });
     chai.expect(translate.callCount).to.equal(1);
     chai.expect(translate.args[0][0]).to.equal('sys.form_not_found');
     chai.expect(translate.args[0][1]).to.equal('es');
@@ -156,7 +156,7 @@ describe('record-utils-parser', () => {
       from: '+888',
       message: '1!0000!2012#2#20#foo#bar'
     };
-    recordUtils.createByForm(body);
+    records.createByForm(body);
     chai.expect(translate.callCount).to.equal(1);
     chai.expect(translate.args[0][0]).to.equal('sys.form_not_found');
     chai.expect(translate.args[0][1]).to.equal('ne');
@@ -172,7 +172,7 @@ describe('record-utils-parser', () => {
       from: '+888',
       message: '1!0000!2012#2#20#foo#bar'
     };
-    recordUtils.createByForm(body);
+    records.createByForm(body);
     chai.expect(translate.callCount).to.equal(1);
     chai.expect(translate.args[0][0]).to.equal('sys.form_not_found');
     chai.expect(translate.args[0][1]).to.equal('en');
@@ -184,7 +184,7 @@ describe('record-utils-parser', () => {
       message: ' '
     };
     sinon.stub(config, 'translate').returns('translated');
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors[0].code).to.equal('sys.empty');
   });
 
@@ -195,7 +195,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message: 'foo'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.form).to.equal(undefined);
   });
 
@@ -207,7 +207,7 @@ describe('record-utils-parser', () => {
       message: '1!YYYY!facility#2011#11#0#1#2#3#4#5#6#9#8#7#6#5#4#123',
       sent_timestamp:'1352399720000'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors.length).to.equal(1);
     chai.expect(doc.errors[0].code).to.equal('extra_fields');
   });
@@ -219,7 +219,7 @@ describe('record-utils-parser', () => {
       from:'+888',
       message: '1!YYYY!foo'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.errors[0].code).to.equal('sys.missing_fields');
     chai.expect(doc.errors[0].ctx.fields).to.deep.equal(['year','month']);
   });
@@ -231,7 +231,7 @@ describe('record-utils-parser', () => {
       from: '+888',
       message: 'hello world! anyone there?'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     // unstructured message has form of null
     chai.expect(doc.form).to.equal(undefined);
     chai.expect(doc.sms_message.message).to.equal('hello world! anyone there?');
@@ -241,7 +241,7 @@ describe('record-utils-parser', () => {
     sinon.stub(config, 'get')
       .withArgs('forms').returns(definitions.forms);
     const body = { from: '+888', message: '' };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.sms_message.message).to.equal('');
   });
 
@@ -253,7 +253,7 @@ describe('record-utils-parser', () => {
       }
     };
     try {
-      recordUtils.createRecordByJSON(body);
+      records.createRecordByJSON(body);
     } catch(e) {
       chai.expect(e.publicMessage).to.equal('Form not found: FOO');
       done();
@@ -272,7 +272,7 @@ describe('record-utils-parser', () => {
         from: '+888'
       }
     };
-    const doc = recordUtils.createRecordByJSON(body);
+    const doc = records.createRecordByJSON(body);
     chai.expect(doc.form).to.equal('YYYY');
     chai.expect(doc.fields.facility_id).to.equal('zanzibar');
     chai.expect(doc.fields.month).to.equal(8);
@@ -288,7 +288,7 @@ describe('record-utils-parser', () => {
         from: '+888'
       }
     };
-    recordUtils.createRecordByJSON(body);
+    records.createRecordByJSON(body);
   });
 
   it('JSON POST: ignore object and null properties', () => {
@@ -307,7 +307,7 @@ describe('record-utils-parser', () => {
         from: '+888'
       }
     };
-    const doc = recordUtils.createRecordByJSON(body);
+    const doc = records.createRecordByJSON(body);
     chai.expect(doc.fields.facility_id).to.equal('zanzibar');
     chai.expect(doc.fields.year).to.equal(2011);
     chai.expect(doc.fields.age).to.equal(undefined);
@@ -326,7 +326,7 @@ describe('record-utils-parser', () => {
         from: '+888'
       }
     };
-    const doc = recordUtils.createRecordByJSON(body);
+    const doc = records.createRecordByJSON(body);
     chai.expect(doc.fields.facility_id).to.equal('zanzibar');
     chai.expect(doc.fields.year).to.equal(2011);
   });
@@ -344,7 +344,7 @@ describe('record-utils-parser', () => {
         from: '+888'
       }
     };
-    const doc = recordUtils.createRecordByJSON(body);
+    const doc = records.createRecordByJSON(body);
     chai.expect(doc.reported_date).to.equal(1421177819013);
     chai.expect(doc.fields.facility_id).to.equal('zanzibar');
     chai.expect(doc.fields.year).to.equal(2011);

--- a/api/tests/mocha/services/record-parser.spec.js
+++ b/api/tests/mocha/services/record-parser.spec.js
@@ -221,7 +221,6 @@ describe('record parser', () => {
     };
     const doc = records.createByForm(body);
     chai.expect(doc.errors[0].code).to.equal('sys.missing_fields');
-    chai.expect(doc.errors[0].ctx.fields).to.deep.equal(['year','month']);
   });
 
   it('support unstructured message', () => {

--- a/api/tests/mocha/services/record-public-forms.spec.js
+++ b/api/tests/mocha/services/record-public-forms.spec.js
@@ -2,9 +2,9 @@ const sinon = require('sinon'),
       chai = require('chai'),
       definitions = require('../../form-definitions'),
       config = require('../../../src/config'),
-      recordUtils = require('../../../src/controllers/record-utils');
+      records = require('../../../src/services/records');
 
-describe('record-utils-public-forms', () => {
+describe('records-public-forms', () => {
 
   afterEach(() => {
     sinon.restore();
@@ -17,7 +17,7 @@ describe('record-utils-public-forms', () => {
       message: '1!YYYW!facility#foo',
       sent_timestamp: '1352399720000'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.fields.foo).to.equal('foo'); // make sure form parsed correctly
     chai.expect(doc.from).to.equal(body.from);
     chai.expect(doc.errors.length).to.equal(0);
@@ -30,7 +30,7 @@ describe('record-utils-public-forms', () => {
       message: '1!YYYZ!one#two#20111010',
       sent_timestamp: '1352399720000'
     };
-    const doc = recordUtils.createByForm(body);
+    const doc = records.createByForm(body);
     chai.expect(doc.fields.two).to.equal('two'); // make sure form parsed correctly
     chai.expect(doc.from).to.equal(body.from);
     chai.expect(doc.errors.length).to.equal(0);

--- a/api/tests/mocha/services/record-timestamp.spec.js
+++ b/api/tests/mocha/services/record-timestamp.spec.js
@@ -1,5 +1,5 @@
 const chai = require('chai'),
-      recordUtils = require('../../../src/controllers/record-utils');
+      records = require('../../../src/services/records');
 
 const process = timestamp => {
   const body = {
@@ -7,11 +7,11 @@ const process = timestamp => {
     message: 'hmm this is test',
     sent_timestamp: timestamp
   };
-  const doc = recordUtils.createByForm(body);
+  const doc = records.createByForm(body);
   return new Date(doc.reported_date);
 };
 
-describe('record-utils-timestamp', () => {
+describe('record timestamp', () => {
 
   it('ms since epoch', () => {
     const actual = process('1352659197736');

--- a/api/tests/mocha/services/record-validate.spec.js
+++ b/api/tests/mocha/services/record-validate.spec.js
@@ -1,7 +1,7 @@
 const chai = require('chai'),
       validate = require('../../../src/services/report/validate');
 
-describe('record-utils-validate', () => {
+describe('records validate', () => {
 
   /*
    * check that missing fields are logged as errors.

--- a/api/tests/mocha/services/record.spec.js
+++ b/api/tests/mocha/services/record.spec.js
@@ -1,10 +1,10 @@
-const controller = require('../../../src/controllers/record-utils'),
+const service = require('../../../src/services/records'),
       chai = require('chai'),
       definitions = require('../../form-definitions'),
       config = require('../../../src/config'),
       sinon = require('sinon');
 
-describe('record-utils', () => {
+describe('records', () => {
 
   afterEach(() => {
     sinon.restore();
@@ -15,14 +15,14 @@ describe('record-utils', () => {
     const body = Object.create(null);
     body.message = 'test';
     body.from = '+123';
-    const doc = controller.createByForm(body);
+    const doc = service.createByForm(body);
     chai.expect(doc.from).to.equal(body.from);
     done();
   });
 
   it('create form returns error if form value is missing', done => {
     try {
-      controller.createByForm({ message: 'test' });
+      service.createByForm({ message: 'test' });
     } catch(e) {
       chai.expect(e.publicMessage).to.equal('Missing required value: from');
       done();
@@ -32,7 +32,7 @@ describe('record-utils', () => {
   it('create json returns error if missing _meta property', done => {
     const body = { name: 'bob' };
     try {
-      controller.createRecordByJSON(body);
+      service.createRecordByJSON(body);
     } catch(e) {
       chai.expect(e.publicMessage).to.equal('Missing _meta property.');
       done();
@@ -40,7 +40,7 @@ describe('record-utils', () => {
   });
 
   it('create form', done => {
-    const actual = controller.createByForm({
+    const actual = service.createByForm({
       message: 'test',
       from: '+123',
       unwanted: ';-- DROP TABLE users'
@@ -58,7 +58,7 @@ describe('record-utils', () => {
   it('create json', done => {
     sinon.stub(config, 'get').returns(definitions.forms);
 
-    const actual = controller.createRecordByJSON({
+    const actual = service.createRecordByJSON({
       _meta: {
         form: 'YYYY',
         from: '+123',

--- a/api/tests/mocha/services/records.spec.js
+++ b/api/tests/mocha/services/records.spec.js
@@ -1,7 +1,7 @@
 const controller = require('../../../src/controllers/records'),
       chai = require('chai'),
       auth = require('../../../src/auth'),
-      recordUtils = require('../../../src/controllers/record-utils'),
+      records = require('../../../src/services/records'),
       sinon = require('sinon'),
       config = require('../../../src/config');
 
@@ -15,8 +15,8 @@ describe('records controller', () => {
     sinon.stub(auth, 'check').resolves();
     const reqIs = sinon.stub().returns(false);
     reqIs.withArgs('json').returns('json'); // yes, it actually returns 'json'
-    const createRecordByJSON = sinon.stub(recordUtils, 'createRecordByJSON').returns({ message: 'one' });
-    const createByForm = sinon.stub(recordUtils, 'createByForm');
+    const createRecordByJSON = sinon.stub(records, 'createRecordByJSON').returns({ message: 'one' });
+    const createByForm = sinon.stub(records, 'createByForm');
     const json = sinon.stub();
     const req = {
       body: {
@@ -46,8 +46,8 @@ describe('records controller', () => {
     sinon.stub(auth, 'check').resolves();
     const reqIs = sinon.stub().returns(false);
     reqIs.withArgs('urlencoded').returns('urlencoded');
-    const createRecordByJSON = sinon.stub(recordUtils, 'createRecordByJSON');
-    const createByForm = sinon.stub(recordUtils, 'createByForm').returns({ message: 'one' });
+    const createRecordByJSON = sinon.stub(records, 'createRecordByJSON');
+    const createByForm = sinon.stub(records, 'createByForm').returns({ message: 'one' });
     const json = sinon.stub();
     const req = {
       body: {

--- a/api/tests/mocha/services/report/smsparser.spec.js
+++ b/api/tests/mocha/services/report/smsparser.spec.js
@@ -115,13 +115,6 @@ describe('sms parser', () => {
     chai.expect(data.month).to.equal(10);
   });
 
-  it('validations is numeric month stays numeric', () => {
-    const doc = { message: '1!YYYY!foo#2011#11#' };
-    const def = definitions.forms.YYYY;
-    const data = smsparser.parse(def, doc);
-    chai.expect(data.month).to.equal(11);
-  });
-
   it('form not found', () => {
     const doc = {
       message:'1!X0X0!facility#2011#11#1#2#3#4#5#6#9#8#7#6#5#4',
@@ -144,7 +137,7 @@ describe('sms parser', () => {
     chai.expect(data).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: null,
       quantity_dispensed: {
         la_6x1: null,
@@ -176,7 +169,7 @@ describe('sms parser', () => {
     chai.expect(data).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: true,
       quantity_dispensed: {
         la_6x1: 1,
@@ -208,7 +201,7 @@ describe('sms parser', () => {
     chai.expect(data).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: false,
       quantity_dispensed: {
         la_6x1: 1,
@@ -739,7 +732,7 @@ describe('sms parser', () => {
     chai.expect(actual).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: false,
       quantity_dispensed: {
         la_6x1: 1,
@@ -776,7 +769,7 @@ describe('sms parser', () => {
     chai.expect(actual).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: false,
       quantity_dispensed: {
         la_6x1: 1,
@@ -812,7 +805,7 @@ describe('sms parser', () => {
     chai.expect(actual).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: false,
       quantity_dispensed: {
         la_6x1: 1,
@@ -848,7 +841,7 @@ describe('sms parser', () => {
     chai.expect(actual).to.deep.equal({
       facility_id: 'facility',
       year: 2011,
-      month: 11,
+      month: 'November',
       misoprostol_administered: false,
       quantity_dispensed: {
         la_6x1: undefined,
@@ -884,7 +877,7 @@ describe('sms parser', () => {
     chai.expect(actual).to.deep.equal({
       facility_id: 'fa\\cility#2#3',
       year: undefined,
-      month: undefined,
+      month: null,
       misoprostol_administered: undefined,
       quantity_dispensed: {
         la_6x1: undefined,

--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1227,3 +1227,4 @@ report.immunization_visit.vaccines_received.received_fipv_1 = Fractional IPV 1
 report.immunization_visit.vaccines_received.received_fipv_2 = Fractional IPV 2
 report.immunization_visit.vaccines_received.received_dpt_4 = DPT Booster 1
 report.immunization_visit.vaccines_received.received_dpt_5 = DPT Booster 2
+sys.incorrect_type = Incorrect type of field {{key}}, expected {{expectedType}}.

--- a/tests/e2e/api/controllers/records.spec.js
+++ b/tests/e2e/api/controllers/records.spec.js
@@ -21,6 +21,12 @@ describe('Import Records', () => {
             'type': 'integer',
             'required': true
           },
+          'a_boolean': {
+            'type': 'boolean',
+          },
+          'another_boolean': {
+            'type': 'boolean',
+          },
           'an_optional_date': {
             'type': 'date'
           }
@@ -50,6 +56,8 @@ describe('Import Records', () => {
           },
           some_data: 'hello',
           a_number: 42,
+          a_boolean: false,
+          another_boolean: 0,
           an_optional_date: '2018-11-10'
         }
       }))
@@ -69,6 +77,8 @@ describe('Import Records', () => {
         expect(doc.fields).to.deep.equal({
           some_data: 'hello',
           a_number: 42,
+          a_boolean: false,
+          another_boolean: false,
           an_optional_date: moment('2018-11-10').valueOf()
         });
         return utils.db.remove(doc);

--- a/tests/e2e/api/controllers/records.spec.js
+++ b/tests/e2e/api/controllers/records.spec.js
@@ -165,7 +165,8 @@ describe('Import Records', () => {
         });
         expect(doc.errors.length).to.equal(1);
         expect(doc.errors[0]).to.deep.equal({
-          blah: 'wrong'
+          code: 'sys.missing_fields',
+          message: 'Missing or invalid fields: some_data.'
         });
         return utils.db.remove(doc);
       });

--- a/tests/e2e/api/controllers/records.spec.js
+++ b/tests/e2e/api/controllers/records.spec.js
@@ -1,0 +1,164 @@
+const { expect } = require('chai');
+const moment = require('moment');
+const utils = require('../../../utils');
+
+describe('Import Records', () => {
+
+  afterAll(() => utils.deleteAllDocs().then(() => utils.revertSettings()));
+
+  beforeAll(() => utils.updateSettings({
+    forms: {
+      'TEST': {
+        'meta':{
+          'code': 'TEST'
+        },
+        'fields': {
+          'some_data': {
+            'type': 'string',
+            'required': true
+          },
+          'a_number': {
+            'type': 'integer',
+            'required': true
+          },
+          'an_optional_date': {
+            'type': 'date'
+          }
+        }
+      }
+    }
+  }));
+
+  describe('JSON', () => {
+    it('parses and stores the passed JSON', () => {
+      return utils.saveDoc({
+        name: 'Test contact',
+        phone: '+447765902000',
+        reported_date: 1557404580557,
+        type: 'person'
+      })
+      .then(() => utils.request({
+        method: 'POST',
+        path: '/api/v2/records',
+        headers: {
+          'Content-type': 'application/json'
+        },
+        body: {
+          _meta: {
+            form: 'TEST',
+            from: '+447765902000'
+          },
+          some_data: 'hello',
+          a_number: 42,
+          an_optional_date: '2018-11-10'
+        }
+      }))
+      .then(() => utils.db.query('medic-client/reports_by_form', {
+        key: ['TEST'],
+        include_docs: true,
+        reduce: false
+      }))
+      .then(({rows}) => {
+        expect(rows.length).to.equal(1);
+        const doc = rows[0].doc;
+        expect(doc).to.include({
+          type: 'data_record',
+          form: 'TEST',
+          from: '+447765902000'
+        });
+        expect(doc.fields).to.deep.equal({
+          some_data: 'hello',
+          a_number: 42,
+          an_optional_date: moment('2018-11-10').valueOf()
+        });
+        return utils.db.remove(doc);
+      });
+    });
+    it('supports not passing optional fields, including the from number', () => {
+      return utils.saveDoc({
+        name: 'Test contact',
+        phone: '+447765902000',
+        reported_date: 1557404580557,
+        type: 'person'
+      })
+      .then(() => utils.request({
+        method: 'POST',
+        path: '/api/v2/records',
+        headers: {
+          'Content-type': 'application/json'
+        },
+        body: {
+          _meta: {
+            form: 'TEST'
+          },
+          some_data: 'hello',
+          a_number: 42
+        }
+      }))
+      .then(() => utils.db.query('medic-client/reports_by_form', {
+        key: ['TEST'],
+        include_docs: true,
+        reduce: false
+      }))
+      .then(({rows}) => {
+        expect(rows.length).to.equal(1);
+        const doc = rows[0].doc;
+        expect(doc).to.include({
+          type: 'data_record',
+          form: 'TEST'
+        });
+        expect(doc.fields).to.deep.equal({
+          some_data: 'hello',
+          a_number: 42
+        });
+        return utils.db.remove(doc);
+      });
+    });
+    it('adds errors for missing fields', () => {
+      return utils.saveDoc({
+        name: 'Test contact',
+        phone: '+447765902000',
+        reported_date: 1557404580557,
+        type: 'person'
+      })
+      .then(() => utils.request({
+        method: 'POST',
+        path: '/api/v2/records',
+        headers: {
+          'Content-type': 'application/json'
+        },
+        body: {
+          _meta: {
+            form: 'TEST',
+            from: '+447765902000'
+          },
+          a_number: 42,
+          an_optional_date: '2018-11-10'
+        }
+      }))
+      .then(() => utils.db.query('medic-client/reports_by_form', {
+        key: ['TEST'],
+        include_docs: true,
+        reduce: false
+      }))
+      .then(({rows}) => {
+        expect(rows.length).to.equal(1);
+        const doc = rows[0].doc;
+        expect(doc).to.include({
+          type: 'data_record',
+          form: 'TEST',
+          from: '+447765902000'
+        });
+        expect(doc.fields).to.deep.equal({
+          a_number: 42,
+          an_optional_date: moment('2018-11-10').valueOf()
+        });
+        expect(doc.errors.length).to.equal(1);
+        expect(doc.errors[0]).to.deep.equal({
+          blah: 'wrong'
+        });
+        return utils.db.remove(doc);
+      });
+    });
+  });
+});

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -261,7 +261,7 @@ var _ = require('underscore'),
       $scope.loadingSummary = true;
       return $q
         .all([
-          $translate(title),
+          $translate(title).catch(() => title),
           getActionBarDataForChild(ctrl.selected.doc.type),
           getCanEdit(ctrl.selected.doc),
         ])


### PR DESCRIPTION
Removed the requirement to provide a phone number (if you're from an
external facility you may not have a representitive phone number).

Added a 'complex' data type which lets JSON-backed JSON forms pass
complex JSON data in.

Added validation for JSON forms that come in as actual JSON, to give
type fields a point.

Removed features that are undocumented and (as far as I can tell from
actively supported projects) no longer used:

 - Mapping SMS data into JSON paths
 - is_numeric_years|months|days, which were in various levels of support
   and reference in the codebase
 - "autoreply" and "messages_task", which were referenced in test data
   but had not associated features
 - arbitrary eval-based (with magic scoping) validation that wasn't used
   anywhere

General code cleanup to remove code that didn't make sense anymore,
align code expectations with documentation.

medic/medic#5589
