### PR TITLE
infodoc creation will use original doc transitions if it has to

### DIFF
--- a/shared-libs/transitions/src/lib/infodoc.js
+++ b/shared-libs/transitions/src/lib/infodoc.js
@@ -37,12 +37,12 @@ const getInfoDoc = change => {
       });
     })
     .then(doc => {
-      if (doc) {
-        doc.transitions = doc.transitions || change.doc.transitions || {};
-        return doc;
-      } else {
-        return createInfoDoc(change.id, 'unknown');
+      if (!doc) {
+        doc = createInfoDoc(change.id, 'unknown');
       }
+
+      doc.transitions = doc.transitions || change.doc.transitions || {};
+      return doc;
     })
     .then(doc => updateInfoDoc(doc, rev));
 };

--- a/shared-libs/transitions/test/integration/transitions.js
+++ b/shared-libs/transitions/test/integration/transitions.js
@@ -246,7 +246,7 @@ describe('functional transitions', () => {
         assert.isUndefined(result);
         assert.equal(db.sentinel.get.callCount, 1);
         assert.equal(db.sentinel.put.callCount, 1); // initial creation
-        assert.isUndefined(db.sentinel.put.args[0][0].transitions);
+        assert.deepEqual(db.sentinel.put.args[0][0].transitions, {});
         done();
       });
     });


### PR DESCRIPTION
If there is no infodoc in either sentinel or medic we should still try to use 
transition information from the existing document if it exists.