### PR TITLE
Cache the path accessed from _rewrite

### DIFF
--- a/api/src/public/appcache-upgrade.html
+++ b/api/src/public/appcache-upgrade.html
@@ -3,7 +3,7 @@ This loads as an empty page at /medic/_design/medic/_rewire/ which is served to 
 This page clears the appcache (by requesitng no manifest) and redirects to root
 -->
 
-<html manifest="manifest.appcache">
+<html>
   <head>
     <meta http-equiv="refresh" content="0; url=/" />
   </head>

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -181,7 +181,7 @@ app.get('/dbinfo', (req, res) => {
   proxy.web(req, res);
 });
 
-app.get(appPrefix, (req, res) => proxy.web(req, res));
+app.get(appPrefix, (req, res) => res.sendFile(path.join(__dirname, 'public/appcache-upgrade.html')));
 
 app.all('/medic/*', (req, res, next) => {
   if (environment.db === 'medic') {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -610,14 +610,14 @@ app.get('/service-worker.js', (req, res) => {
 proxy.on('proxyReq', function(proxyReq, req, res) {
   if (
     !staticResources.test(req.url) &&
-    req.url.indexOf(appPrefix) !== -1	
-  ) {	
-    // requesting other application files	
-    writeHeaders(req, res, [], true);	
-  } else {	
-    // everything else	
-    writeHeaders(req, res);	
-  }	
+    req.url.indexOf(appPrefix) !== -1
+  ) {
+    // requesting other application files
+    writeHeaders(req, res, [], true);
+  } else {
+    // everything else
+    writeHeaders(req, res);
+  }
 
   writeParsedBody(proxyReq, req);
 });

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -33,7 +33,6 @@ const _ = require('underscore'),
   bulkDocs = require('./controllers/bulk-docs'),
   authorization = require('./middleware/authorization'),
   createUserDb = require('./controllers/create-user-db'),
-  staticResources = /\/(templates|static)\//,
   // CouchDB is very relaxed in matching routes
   routePrefix = '/+' + environment.db + '/+',
   pathPrefix = '/' + environment.db + '/',
@@ -181,7 +180,7 @@ app.get('/dbinfo', (req, res) => {
   proxy.web(req, res);
 });
 
-app.get(appPrefix, (req, res) => res.sendFile(path.join(__dirname, 'public/appcache-upgrade.html')));
+app.get([`/medic/_design/medic/_rewrite/`, appPrefix], (req, res) => res.sendFile(path.join(__dirname, 'public/appcache-upgrade.html')));
 
 app.all('/medic/*', (req, res, next) => {
   if (environment.db === 'medic') {
@@ -608,17 +607,7 @@ app.get('/service-worker.js', (req, res) => {
  * ensure we set the value first.
  */
 proxy.on('proxyReq', function(proxyReq, req, res) {
-  if (
-    !staticResources.test(req.url) &&
-    req.url.indexOf(appPrefix) !== -1
-  ) {
-    // requesting other application files
-    writeHeaders(req, res, [], true);
-  } else {
-    // everything else
-    writeHeaders(req, res);
-  }
-
+  writeHeaders(req, res);
   writeParsedBody(proxyReq, req);
 });
 

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -33,6 +33,7 @@ const _ = require('underscore'),
   bulkDocs = require('./controllers/bulk-docs'),
   authorization = require('./middleware/authorization'),
   createUserDb = require('./controllers/create-user-db'),
+  staticResources = /\/(templates|static)\//,
   // CouchDB is very relaxed in matching routes
   routePrefix = '/+' + environment.db + '/+',
   pathPrefix = '/' + environment.db + '/',
@@ -607,7 +608,17 @@ app.get('/service-worker.js', (req, res) => {
  * ensure we set the value first.
  */
 proxy.on('proxyReq', function(proxyReq, req, res) {
-  writeHeaders(req, res);
+  if (
+    !staticResources.test(req.url) &&
+    req.url.indexOf(appPrefix) !== -1	
+  ) {	
+    // requesting other application files	
+    writeHeaders(req, res, [], true);	
+  } else {	
+    // everything else	
+    writeHeaders(req, res);	
+  }	
+
   writeParsedBody(proxyReq, req);
 });
 

--- a/ddocs/medic/_attachments/appcache-upgrade.html
+++ b/ddocs/medic/_attachments/appcache-upgrade.html
@@ -3,7 +3,7 @@ This loads as an empty page at /medic/_design/medic/_rewire/ which is served to 
 This page clears the appcache (by requesitng no manifest) and redirects to root
 -->
 
-<html>
+<html manifest="manifest.appcache">
   <head>
     <meta http-equiv="refresh" content="0; url=/" />
   </head>

--- a/ddocs/medic/rewrites.json
+++ b/ddocs/medic/rewrites.json
@@ -1,6 +1,3 @@
 [
-  {"from": "/manifest.appcache",  "to": "manifest.appcache"},
-  {"from": "/",                   "to": "appcache-upgrade.html"},
-  {"from": "#/*",                 "to": "appcache-upgrade.html"},
-  {"from": "/#/*",                "to": "appcache-upgrade.html"}
+  {"from": "/manifest.appcache",  "to": "manifest.appcache"}
 ]

--- a/grunt/service-worker.js
+++ b/grunt/service-worker.js
@@ -35,6 +35,7 @@ function writeServiceWorkerFile({staticDirectoryPath, apiSrcDirectoryPath, scrip
     dynamicUrlToDependencies: {
       '/': [path.join(staticDirectoryPath, 'templates', 'inbox.html')],
       '/medic/login': [path.join(apiSrcDirectoryPath, 'templates/login', 'index.html')],
+      '/medic/_design/medic/_rewrite/': [path.join(apiSrcDirectoryPath, 'public', 'appcache-upgrade.html')],
     },
     ignoreUrlParametersMatching: [/redirect/],
     stripPrefixMulti: {

--- a/tests/e2e/service-worker.js
+++ b/tests/e2e/service-worker.js
@@ -75,6 +75,7 @@ describe('Service worker cache', () => {
       '/login/script.js',
       '/login/style.css',
       '/manifest.json',
+      '/medic/_design/medic/_rewrite/',
       '/medic/login',
       '/xslt/openrosa2html5form.xsl',
       '/xslt/openrosa2xmlmodel.xsl',


### PR DESCRIPTION
# Description

Another regression from #5361. The android app navigates the user to `/medic/_design/medic/_rewrite/` and does not use the root url. To support offline mode, we need to ensure that a redirect from that rewrite page to root is cached.

I see a few options here: 

1. Existing service workers - The `appcache-upgrade.html` could register the existing service-worker and redirect once registration completes. During an upgrade this would load all of the app's resources during an empty page and is not ideal.
1. Appcache - Given that we have the appropriate manifest already in place (required for the upgrade process), I think this is the easiest and is the fix I pursued here.
1. New service worker - Could also do this. But it's a new file, a new build step, and a bit of a registration process. If things go wrong on this page, we have no feedback mechanic.
1. I hoped a `301` permanent redirect would work here. But this really complicates how we clear the appcache during the upgrade to service workers.

#3986 

Nasty business in the app since we now navigate to `/rewire`, get an appcached version of that page, redirect to `/`, and get a serviceworker cached version of that page. So I'm coupling this with a build-time flag in the app to avoid this for partners when they migrate to >3.5.
https://github.com/medic/medic-android/pull/70

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
