### PR TITLE
Fixes offline user API restrictions

### DIFF
--- a/api/src/middleware/authorization.js
+++ b/api/src/middleware/authorization.js
@@ -30,16 +30,12 @@ module.exports = {
       .then(next);
   },
 
-  // blocks unauthenticated requests from passing through
-  checkAuth: (req, res, next) => {
+  // blocks offline users not-authorized requests
+  offlineUserFirewall: (req, res, next) => {
     if (!req.userCtx) {
       return serverUtils.notLoggedIn(req, res);
     }
-    next();
-  },
 
-  // blocks offline users not-authorized requests
-  offlineUserFirewall: (req, res, next) => {
     if (!auth.isOnlineOnly(req.userCtx) && !req.authorized) {
       res.status(FIREWALL_ERROR.code);
       return res.json(FIREWALL_ERROR);
@@ -50,6 +46,10 @@ module.exports = {
   // proxies online users requests to CouchDB
   // saves offline user-settings doc in the request object
   onlineUserProxy: (proxy, req, res, next) => {
+    if (!req.userCtx) {
+      return serverUtils.notLoggedIn(req, res);
+    }
+
     if (auth.isOnlineOnly(req.userCtx)) {
       return proxy.web(req, res);
     }
@@ -61,6 +61,10 @@ module.exports = {
   // saves offline user-settings doc in the request object
   // used for audited endpoints
   onlineUserPassThrough:(req, res, next) => {
+    if (!req.userCtx) {
+      return serverUtils.notLoggedIn(req, res);
+    }
+
     if (auth.isOnlineOnly(req.userCtx)) {
       return next('route');
     }

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -184,13 +184,13 @@ app.get([`/medic/_design/medic/_rewrite/`, appPrefix], (req, res) => res.sendFil
 
 app.all('/+medic/+*', (req, res, next) => {
   if (environment.db !== 'medic') {
-    req.url = req.url.replace('/medic/', `/${environment.db}/`);
+    req.url = req.url.replace('/medic/', pathPrefix);
   }
   next();
 });
 
 app.all('/+admin/+*', (req, res, next) => {
-  req.url = req.url.replace('/admin/', `/${adminAppPrefix}/`);
+  req.url = req.url.replace('/admin/', adminAppPrefix);
   next();
 });
 

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -235,7 +235,7 @@ const ONLINE_ONLY_ENDPOINTS = [
 
 // block offline users from accessing some unaudited CouchDB endpoints
 ONLINE_ONLY_ENDPOINTS.forEach(url =>
-  app.all(routePrefix + url, authorization.checkAuth, authorization.offlineUserFirewall)
+  app.all(routePrefix + url, authorization.offlineUserFirewall)
 );
 
 var UNAUDITED_ENDPOINTS = [
@@ -410,13 +410,11 @@ const changesHandler = require('./controllers/changes').request,
 
 app.get(
   changesPath,
-  authorization.checkAuth,
   onlineUserChangesProxy,
   changesHandler
 );
 app.post(
   changesPath,
-  authorization.checkAuth,
   onlineUserChangesProxy,
   jsonParser,
   changesHandler
@@ -426,10 +424,9 @@ app.post(
 const allDocsHandler = require('./controllers/all-docs').request,
   allDocsPath = routePrefix + '_all_docs(/*)?';
 
-app.get(allDocsPath, authorization.checkAuth, onlineUserProxy, allDocsHandler);
+app.get(allDocsPath, onlineUserProxy, allDocsHandler);
 app.post(
   allDocsPath,
-  authorization.checkAuth,
   onlineUserProxy,
   jsonParser,
   allDocsHandler
@@ -439,7 +436,6 @@ app.post(
 const bulkGetHandler = require('./controllers/bulk-get').request;
 app.post(
   routePrefix + '_bulk_get(/*)?',
-  authorization.checkAuth,
   onlineUserProxy,
   jsonParser,
   bulkGetHandler
@@ -449,7 +445,6 @@ app.post(
 // this is an audited endpoint: online and filtered offline requests will pass through to the audit route
 app.post(
   routePrefix + '_bulk_docs(/*)?',
-  authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonParser,
   bulkDocs.request,
@@ -465,7 +460,6 @@ const dbDocHandler = require('./controllers/db-doc'),
 
 app.get(
   ddocPath,
-  authorization.checkAuth,
   onlineUserProxy,
   _.partial(dbDocHandler.requestDdoc, environment.ddoc),
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
@@ -473,13 +467,11 @@ app.get(
 
 app.get(
   docPath,
-  authorization.checkAuth,
   onlineUserProxy, // online user GET requests are proxied directly to CouchDB
   dbDocHandler.request
 );
 app.post(
   routePrefix,
-  authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonParser, // request body must be json
   dbDocHandler.request,
@@ -487,7 +479,6 @@ app.post(
 );
 app.put(
   docPath,
-  authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   jsonParser,
   dbDocHandler.request,
@@ -495,14 +486,12 @@ app.put(
 );
 app.delete(
   docPath,
-  authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   dbDocHandler.request,
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
 );
 app.all(
   attachmentPath,
-  authorization.checkAuth,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   dbDocHandler.request,
   authorization.setAuthorized // adds the `authorized` flag to the `req` object, so it passes the firewall
@@ -635,7 +624,7 @@ app.all(appPrefix + '*', authorization.setAuthorized);
 // block offline users requests from accessing CouchDB directly, via Proxy
 // requests which are authorized (fe: by BulkDocsHandler or DbDocHandler) can pass through
 // unauthenticated requests will be redirected to login or given a meaningful error
-app.use(authorization.checkAuth, authorization.offlineUserFirewall);
+app.use(authorization.offlineUserFirewall);
 
 var canEdit = function(req, res) {
   auth

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -235,7 +235,7 @@ const ONLINE_ONLY_ENDPOINTS = [
 
 // block offline users from accessing some unaudited CouchDB endpoints
 ONLINE_ONLY_ENDPOINTS.forEach(url =>
-  app.all(routePrefix + url, authorization.offlineUserFirewall)
+  app.all(routePrefix + url, authorization.checkAuth, authorization.offlineUserFirewall)
 );
 
 var UNAUDITED_ENDPOINTS = [
@@ -635,7 +635,7 @@ app.all(appPrefix + '*', authorization.setAuthorized);
 // block offline users requests from accessing CouchDB directly, via Proxy
 // requests which are authorized (fe: by BulkDocsHandler or DbDocHandler) can pass through
 // unauthenticated requests will be redirected to login or given a meaningful error
-app.use(authorization.offlineUserFirewall);
+app.use(authorization.checkAuth, authorization.offlineUserFirewall);
 
 var canEdit = function(req, res) {
   auth

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -189,14 +189,9 @@ app.all('/+medic/+*', (req, res, next) => {
   next();
 });
 
-app.all('/admin*', (req, res) => {
-  const originalUrl = req.url;
-  if (originalUrl.split('/')[2] === 'fonts') {
-    res.redirect(req.url.slice(6));
-  } else {
-    req.url = `${adminAppPrefix}${originalUrl.slice(7)}`;
-    proxy.web(req, res);
-  }
+app.all('/+admin/+*', (req, res, next) => {
+  req.url = req.url.replace('/admin/', `/${adminAppPrefix}/`);
+  next();
 });
 
 app.get('/favicon.ico', (req, res) => {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -182,15 +182,15 @@ app.get('/dbinfo', (req, res) => {
 
 app.get([`/medic/_design/medic/_rewrite/`, appPrefix], (req, res) => res.sendFile(path.join(__dirname, 'public/appcache-upgrade.html')));
 
-app.all('/+medic/+*', (req, res, next) => {
+app.all('/+medic(/*)?', (req, res, next) => {
   if (environment.db !== 'medic') {
-    req.url = req.url.replace('/medic/', pathPrefix);
+    req.url = req.url.replace(/\/medic\/?/, pathPrefix);
   }
   next();
 });
 
-app.all('/+admin/+*', (req, res, next) => {
-  req.url = req.url.replace('/admin/', adminAppPrefix);
+app.all('/+admin(/*)?', (req, res, next) => {
+  req.url = req.url.replace(/\/admin\/?/, adminAppPrefix);
   next();
 });
 

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -13,7 +13,7 @@ class BaseConfig {
     this.config = {
       seleniumAddress: 'http://localhost:4444/wd/hub',
 
-      specs: [`${testSrcDir}/**/*.js`],
+      specs: [`${testSrcDir}/**/routing.js`],
 
       framework: 'jasmine2',
       capabilities: {

--- a/tests/base.conf.js
+++ b/tests/base.conf.js
@@ -13,7 +13,7 @@ class BaseConfig {
     this.config = {
       seleniumAddress: 'http://localhost:4444/wd/hub',
 
-      specs: [`${testSrcDir}/**/routing.js`],
+      specs: [`${testSrcDir}/**/*.js`],
 
       framework: 'jasmine2',
       capabilities: {

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -903,6 +903,17 @@ describe('changes handler', () => {
        });
     });
 
+    it('should forward changes requests from medic to the used database', () => {
+      return utils
+        .requestOnMedicDb(_.defaults({ path: '/_changes' }, { auth: `bob:${password}` }))
+        .then(results => {
+          return assertChangeIds(results,
+            'org.couchdb.user:bob',
+            'fixture:bobville',
+            'fixture:user:bob');
+      });
+    });
+
     it('filters calls with irregular urls which match couchdb endpoint', () => {
       const options = {
         auth: `bob:${password}`,
@@ -922,7 +933,19 @@ describe('changes handler', () => {
             .catch(err => err),
           utils
             .request(_.defaults({ path: `//${constants.DB_NAME}//_changes//dsadada` }, options))
-            .catch(err => err)
+            .catch(err => err),
+          utils.requestOnMedicDb(_.defaults({ path: '/_changes' }, options)),
+          utils.requestOnMedicDb(_.defaults({ path: '//_changes//' }, options)),
+          utils.request(_.defaults({ path: `//medic//_changes` }, options)),
+          utils
+            .requestOnMedicDb(_.defaults({ path: '/_changes/dsad' }, options))
+            .catch(err => err),
+          utils
+            .requestOnMedicDb(_.defaults({ path: '//_changes//dsada' }, options))
+            .catch(err => err),
+          utils
+            .request(_.defaults({ path: `//medic//_changes//dsadada` }, options))
+            .catch(err => err),
         ])
         .then(results => {
           results.forEach(result => {

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -903,7 +903,7 @@ describe('changes handler', () => {
        });
     });
 
-    it('should forward changes requests from medic to the used database', () => {
+    it('should forward changes requests when db name is not medic', () => {
       return utils
         .requestOnMedicDb(_.defaults({ path: '/_changes' }, { auth: `bob:${password}` }))
         .then(results => {

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -280,6 +280,27 @@ describe('all_docs handler', () => {
       });
   });
 
+  it('filters offline users results when db name is not medic', () => {
+    const docs = [
+      { _id: 'allowed_contact', parent: { _id: 'fixture:offline'}, type: 'clinic' },
+      { _id: 'allowed_report', contact: { _id: 'fixture:offline'}, type: 'data_record', form: 'a' },
+      { _id: 'denied_contact', parent: { _id: 'fixture:online'}, type: 'clinic' },
+      { _id: 'denied_report', contact: { _id: 'fixture:online'}, type: 'data_record', form: 'a' },
+    ];
+
+    return utils
+      .saveDocs(docs)
+      .then(() => utils.requestOnMedicDb(offlineRequestOptions)).then(result => {
+        expect(unrestrictedKeys.every(id => result.rows.find(row => row.id === id || row.id.match(id)))).toBe(true);
+        expect(restrictedKeys.some(id => result.rows.find(row => row.id === id || row.id.match(id)))).toBe(false);
+
+        expect(result.rows.findIndex(row => row.id === 'allowed_contact')).not.toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'allowed_report')).not.toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'denied_contact')).toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'denied_contact')).toEqual(-1);
+      });
+  });
+
   it('restricts calls with irregular urls which match couchdb endpoint', () => {
     const doc = { _id: 'denied_report', contact: { _id: 'fixture:online'}, type: 'data_record', form: 'a' };
 
@@ -297,6 +318,18 @@ describe('all_docs handler', () => {
           .catch(err => err),
         utils
           .request(_.defaults({ path: `//${constants.DB_NAME}//_all_docs/something?key="denied_report"` }, offlineRequestOptions))
+          .catch(err => err),
+        utils.requestOnMedicDb(_.defaults({ path: '/_all_docs?key="denied_report"' }, offlineRequestOptions)),
+        utils.requestOnMedicDb(_.defaults({ path: '///_all_docs//?key="denied_report"' }, offlineRequestOptions)),
+        utils.request(_.defaults({ path: `//medic//_all_docs?key="denied_report"` }, offlineRequestOptions)),
+        utils
+          .requestOnMedicDb(_.defaults({ path: '/_all_docs/something?key="denied_report"' }, offlineRequestOptions))
+          .catch(err => err),
+        utils
+          .requestOnMedicDb(_.defaults({ path: '///_all_docs//something?key="denied_report"' }, offlineRequestOptions))
+          .catch(err => err),
+        utils
+          .request(_.defaults({ path: `//medic//_all_docs/something?key="denied_report"` }, offlineRequestOptions))
           .catch(err => err)
       ]))
       .then(results => {

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -1481,17 +1481,10 @@ describe('db-doc handler', () => {
           .requestOnMedicDb(_.defaults({ path: '/_design/medic-admin' }, request, offlineRequestOptions))
           .catch(err => err),
       ]).then(results => {
-        expect(results[0].statusCode).toEqual(403);
-        expect(results[0].responseBody.error).toEqual('forbidden');
-
-        expect(results[1].statusCode).toEqual(403);
-        expect(results[1].responseBody.error).toEqual('forbidden');
-
-        expect(results[2].statusCode).toEqual(403);
-        expect(results[2].responseBody.error).toEqual('forbidden');
-
-        expect(results[3].statusCode).toEqual(403);
-        expect(results[3].responseBody.error).toEqual('forbidden');
+        results.forEach(result => {
+          expect(result.statusCode).toEqual(403);
+          expect(result.responseBody.error).toEqual('forbidden');
+        });
       });
     });
   });

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -1278,6 +1278,51 @@ describe('db-doc handler', () => {
           expect(results[5].responseBody).toEqual({ error: 'forbidden', reason: 'Insufficient privileges' });
         });
     });
+
+    it('GET attachment', () => {
+      return utils
+        .saveDoc({ _id: 'with_attachments' })
+        .then(result =>
+          utils.requestOnMedicDb({
+            path: `/with_attachments/att_name?rev=${result.rev}`,
+            method: 'PUT',
+            body: 'my attachment content',
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        )
+        .then(() => {
+          onlineRequestOptions.path = '/with_attachments/att_name';
+          return utils.requestOnMedicDb(onlineRequestOptions, false, true);
+        })
+        .then(result => {
+          expect(result).toEqual('my attachment content');
+        });
+    });
+
+    it('PUT attachment', () => {
+      return utils
+        .saveDoc({ _id: 'with_attachments' })
+        .then(result => {
+          _.extend(onlineRequestOptions, {
+            path: `/with_attachments/new_attachment?rev=${result.rev}`,
+            method: 'PUT',
+            headers: { 'Content-Type': 'text/plain' },
+            body: 'my new attachment content',
+          });
+
+          return utils.requestOnMedicDb(onlineRequestOptions);
+        })
+        .then(result =>
+          utils.requestOnMedicDb(
+            `/with_attachments/new_attachment?rev=${result.rev}`,
+            false,
+            true
+          )
+        )
+        .then(result => {
+          expect(result).toEqual('my new attachment content');
+        });
+    });
   });
 
   it('restricts calls with irregular urls which match couchdb endpoints', () => {

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -96,7 +96,7 @@ describe('routing', () => {
     it('API restricts endpoints which need authorization', () => {
       return Promise.all([
         utils
-          .requestOnTestDb(_.extend({ path: '/_design/medic/_view/someview' }, unauthenticatedRequestOptions))
+          .requestOnTestDb(_.extend({ path: '/_design/medic/_view/someview' }, unauthenticatedRequestOptions)) // 403
           .catch(err => err),
         utils
           .requestOnTestDb(_.extend({ path: '/explain' }, unauthenticatedRequestOptions))
@@ -111,7 +111,7 @@ describe('routing', () => {
           .requestOnTestDb(_.extend({ path: '/PARENT_PLACE/attachment' }, unauthenticatedRequestOptions))
           .catch(err => err),
         utils
-          .request(_.extend({ path: '/some-new-db' }, unauthenticatedRequestOptions))
+          .request(_.extend({ path: '/some-new-db' }, unauthenticatedRequestOptions)) // 403
           .catch(err => err),
         utils
           .requestOnMedicDb(_.extend({ path: '/_design/medic/_view/someview' }, unauthenticatedRequestOptions))
@@ -129,7 +129,10 @@ describe('routing', () => {
           .requestOnMedicDb(_.extend({ path: '/PARENT_PLACE/attachment' }, unauthenticatedRequestOptions))
           .catch(err => err),
       ]).then(results => {
-        expect(results.every(result => result.statusCode === 401 || result.statusCode === 403)).toBe(true);
+        results.forEach(result => {
+          expect(result.statusCode).toEqual(401);
+          expect(result.responseBody.error).toEqual('unauthorized');
+        });
       });
     });
 
@@ -179,7 +182,7 @@ describe('routing', () => {
             expect(result.statusCode).toEqual(404);
             expect(result.responseBody.error).toEqual('not_found');
           } else {
-            //offline results
+            // offline user requests
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -214,11 +217,11 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.statusCode).toEqual(404);
             expect(result.responseBody.error).toEqual('not_found');
           } else {
-            // offline result
+            // offline user requests
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -252,11 +255,11 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.statusCode).toEqual(404);
             expect(result.responseBody.error).toEqual('not_found');
           } else {
-            // offline result
+            // offline user requests
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -296,10 +299,10 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.docs.length).toBeTruthy();
           } else {
-            // offline result
+            // offline user request
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -339,11 +342,11 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.limit).toEqual(1);
             expect(result.fields).toEqual('all_fields');
           } else {
-            // offline result
+            // offline user requests
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -377,11 +380,11 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.total_rows).toEqual(1);
             expect(result.indexes.length).toEqual(1);
           } else {
-            // offline result
+            // offline user request
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -420,10 +423,10 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.ok).toEqual(true);
           } else {
-            // offline result
+            // offline user request
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -457,10 +460,10 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach((result, idx) => {
           if (idx === 0) {
-            // online result
+            // online user request
             expect(result.statusCode).toBeFalsy();
           } else {
-            // offline result
+            // offline user requests
             expect(result.statusCode).toEqual(403);
             expect(result.responseBody.error).toEqual('forbidden');
           }
@@ -496,7 +499,6 @@ describe('routing', () => {
           .catch(err => err)
       ]).then(results => {
         results.forEach(result => {
-          // offline result
           expect(result.statusCode).toEqual(403);
           expect(result.responseBody.error).toEqual('forbidden');
         });
@@ -592,7 +594,10 @@ describe('routing', () => {
             .catch(err => err)
         ])
         .then(results => {
-          expect(results.every(result => result.statusCode === 403 && result.responseBody.error === 'forbidden')).toBe(true);
+          results.forEach(result => {
+            expect(result.statusCode).toEqual(403);
+            expect(result.responseBody.error).toEqual('forbidden');
+          });
         });
     });
 
@@ -617,7 +622,10 @@ describe('routing', () => {
           .request(_.extend({ path: '/a/b/c' }, offlineRequestOptions))
           .catch(err => err)
       ]).then(results => {
-        expect(results.every(result => result.statusCode === 403 && result.responseBody.error === 'forbidden')).toBe(true);
+        results.forEach(result => {
+          expect(result.statusCode).toEqual(403);
+          expect(result.responseBody.error).toEqual('forbidden');
+        });
       });
     });
   });

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -582,6 +582,9 @@ describe('routing', () => {
             .requestOnMedicDb(_.defaults({ path: '/_design/medic-admin/css/main.css' }, offlineRequestOptions))
             .catch(err => err),
           utils
+            .request(_.extend({ path: `/admin` }, offlineRequestOptions))
+            .catch(err => err),
+          utils
             .request(_.extend({ path: `/admin/` }, offlineRequestOptions))
             .catch(err => err),
           utils

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -552,13 +552,11 @@ describe('routing', () => {
       return Promise.all([
         utils.requestOnTestDb(_.defaults({ path: '/_design/medic/_rewrite' }, offlineRequestOptions), false, true),
         utils.requestOnTestDb(_.defaults({ path: '/' }, offlineRequestOptions), false, true),
-        utils.requestOnMedicDb(_.defaults({ path: '/_design/medic/_rewrite' }, offlineRequestOptions), false, true),
-        utils.requestOnMedicDb(_.defaults({ path: '/' }, offlineRequestOptions), false, true),
+        utils.requestOnMedicDb(_.defaults({ path: '/_design/medic/_rewrite' }, offlineRequestOptions), false, true)
       ]).then(results => {
         expect(results[0].includes('Found. Redirecting to')).toBe(true);
         expect(results[1].includes('DOCTYPE html')).toBe(true);
         expect(results[2].includes('Found. Redirecting to')).toBe(true);
-        expect(results[3].includes('DOCTYPE html')).toBe(true);
       });
     });
 

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -129,7 +129,7 @@ describe('routing', () => {
           .requestOnMedicDb(_.extend({ path: '/PARENT_PLACE/attachment' }, unauthenticatedRequestOptions))
           .catch(err => err),
       ]).then(results => {
-        expect(results.every(result => result.statusCode === 401 && result.responseBody.error === 'unauthorized'));
+        expect(results.every(result => result.statusCode === 401 || result.statusCode === 403)).toBe(true);
       });
     });
 

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -643,7 +643,7 @@ describe('registration', () => {
         //1st doc has cleared schedules
         expect(updated[0].scheduled_tasks).toBeDefined();
         expect(updated[0].scheduled_tasks.length).toEqual(3);
-        expect(updated[0].scheduled_tasks.every(task => task.state === 'cleared'));
+        expect(updated[0].scheduled_tasks.every(task => task.state === 'cleared')).toBe(true);
 
         //2nd doc has schedules
         expect(updated[1].scheduled_tasks).toBeDefined();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -349,6 +349,20 @@ module.exports = {
     return request(options, { debug: debug, notJson: notJson });
   },
 
+  requestOnMedicDb: (options, debug, notJson) => {
+    if (typeof options === 'string') {
+      options = {
+        path: options,
+      };
+    }
+
+    const pathAndReqType = `${options.path}${options.method}`;
+    if (pathAndReqType !== '/GET') {
+      options.path = `/medic${options.path}`;
+    }
+    return request(options, { debug: debug, notJson: notJson });
+  },
+
   saveDoc: doc => {
     const postData = JSON.stringify(doc);
     return module.exports.requestOnTestDb({

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -351,15 +351,9 @@ module.exports = {
 
   requestOnMedicDb: (options, debug, notJson) => {
     if (typeof options === 'string') {
-      options = {
-        path: options,
-      };
+      options = { path: options };
     }
-
-    const pathAndReqType = `${options.path}${options.method}`;
-    if (pathAndReqType !== '/GET') {
-      options.path = `/medic${options.path}`;
-    }
+    options.path = `/medic${options.path || ''}`;
     return request(options, { debug: debug, notJson: notJson });
   },
 


### PR DESCRIPTION
# Description

When db name is not `medic`, instead of proxying straight to CouchDB, changes url to match the DB name and forwards to next route.
Fixes `/admin` prefixed routes from proxying straight to CouchDB.
Updates offline users e2e tests to test with `medic-test` and `medic` dbs urls. 
Adds deprecated API V0 routing e2e testing. 

medic/medic#5692

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
