### PR TITLE
Replicate needs_signoff reports to the whole contact lineage

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -233,7 +233,7 @@ const getAllowedDocIds = (feed) => {
       }
     });
 
-    return validatedIds;
+    return _.uniq(validatedIds);
   });
 };
 

--- a/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/ddocs/medic/views/docs_by_replication_key/map.js
@@ -54,11 +54,15 @@ function (doc) {
       emit(subject, value);
       if (doc.fields &&
           doc.fields.needs_signoff &&
-          doc.contact &&
-          doc.contact._id &&
-          doc.contact._id !== subject
+          doc.contact
       ) {
-        emit(doc.contact._id, value);
+        var contact = doc.contact;
+        while (contact) {
+          if (contact._id && contact._id !== subject) {
+            emit(contact._id, value);
+          }
+          contact = contact.parent;
+        }
       }
       return;
     case 'clinic':

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1184,10 +1184,10 @@ describe('changes handler', () => {
           .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
           .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport ]))
           .then(() => Promise.all([
-            requestChanges('chw'),
-            requestChanges('chw-boss'),
-            requestChanges('supervisor'),
-            requestChanges('bob'),
+            requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place
+            requestChanges('chw-boss'), // chw-boss > chw-bossville > parent_place
+            requestChanges('supervisor'), // supervisor > parent_place
+            requestChanges('bob'), // bob > bobbille > parent_place
           ]))
           .then(([ chwChanges, chwBossChanges, supervisorChanges, bobChanges ]) => {
             assertChangeIds(chwChanges,
@@ -1262,10 +1262,10 @@ describe('changes handler', () => {
           .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
           .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport ]))
           .then(() => Promise.all([
-            requestChanges('chw'),
-            requestChanges('chw-boss'),
-            requestChanges('supervisor'),
-            requestChanges('bob'),
+            requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place
+            requestChanges('chw-boss'), // chw-boss > chw-bossville > parent_place
+            requestChanges('supervisor'), // supervisor > parent_place
+            requestChanges('bob'), // bob > bobbille > parent_place
           ]))
           .then(([ chwChanges, chwBossChanges, supervisorChanges, bobChanges ]) => {
             assertChangeIds(chwChanges,

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -94,7 +94,7 @@ const users = [
     password: password,
     place: {
       _id: 'fixture:chwville',
-      type: 'district_hospital',
+      type: 'clinic',
       name: 'Chwville',
       parent: 'fixture:chw-bossville'
     },
@@ -103,6 +103,16 @@ const users = [
       name: 'CHW'
     },
     roles: ['district_admin', 'analytics']
+  },
+  {
+    username: 'supervisor',
+    password: password,
+    place: 'PARENT_PLACE',
+    contact: {
+      _id: 'fixture:user:supervisor',
+      name: 'Supervisor'
+    },
+    roles: ['district_admin']
   },
   {
     username: 'steve',
@@ -1117,6 +1127,186 @@ describe('changes handler', () => {
               'fixture:chwville',
               'should-be-visible',
               'should-also-be-visible')));
+
+    describe('Needs signoff', () => {
+      beforeEach(done => {
+        const patient = {
+          _id: 'clinic_patient',
+          type: 'person',
+          reported_date: 1,
+          parent: { _id: 'fixture:chwville', parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}}
+        };
+        const healthCenterPatient = {
+          _id: 'health_center_patient',
+          type: 'person',
+          reported_date: 1,
+          parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
+        };
+        utils.saveDocs([patient, healthCenterPatient]).then(done);
+      });
+
+      it('should do nothing when not truthy or not present', () => {
+        const clinicReport = {
+          _id: 'clinic_report',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'clinic_patient' },
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:chw',
+            parent: { _id: 'fixture:chwville', parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}}
+          }
+        };
+        const clinicReport2 = {
+          _id: 'clinic_report_2',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'clinic_patient', needs_signoff: false },
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:chw',
+            parent: { _id: 'fixture:chwville', parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}}
+          }
+        };
+        const healthCenterReport = {
+          _id: 'health_center_report',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'health_center_patient', needs_signoff: ''},
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:chw-boss',
+            parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
+          }
+        };
+
+        return utils
+          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
+          .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport ]))
+          .then(() => Promise.all([
+            requestChanges('chw'),
+            requestChanges('chw-boss'),
+            requestChanges('supervisor'),
+            requestChanges('bob'),
+          ]))
+          .then(([ chwChanges, chwBossChanges, supervisorChanges, bobChanges ]) => {
+            assertChangeIds(chwChanges,
+              'org.couchdb.user:chw',
+              'fixture:user:chw',
+              'fixture:chwville',
+              'clinic_patient',
+              'clinic_report',
+              'clinic_report_2');
+
+            assertChangeIds(chwBossChanges,
+              'org.couchdb.user:chw-boss',
+              'fixture:user:chw-boss',
+              'fixture:chw-bossville',
+              'fixture:chwville',
+              'health_center_patient',
+              'health_center_report');
+
+            assertChangeIds(supervisorChanges,
+              'org.couchdb.user:supervisor',
+              'fixture:user:supervisor',
+              'fixture:chw-bossville',
+              'fixture:managerville',
+              'fixture:clareville',
+              'fixture:steveville',
+              'fixture:bobville',
+              'PARENT_PLACE');
+
+            assertChangeIds(bobChanges,
+              'org.couchdb.user:bob',
+              'fixture:bobville',
+              'fixture:user:bob');
+          });
+      });
+
+      it('should replicate to all ancestors when present and truthy', () => {
+        const clinicReport = {
+          _id: 'clinic_report',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'clinic_patient', needs_signoff: true },
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:chw',
+            parent: { _id: 'fixture:chwville', parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}}
+          }
+        };
+        const clinicReport2 = {
+          _id: 'clinic_report_2',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'clinic_patient', needs_signoff: 'something' },
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:chw',
+            parent: { _id: 'fixture:chwville', parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}}
+          }
+        };
+        const healthCenterReport = {
+          _id: 'health_center_report',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'health_center_patient', needs_signoff: 'YES!'},
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:chw-boss',
+            parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
+          }
+        };
+
+        return utils
+          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
+          .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport ]))
+          .then(() => Promise.all([
+            requestChanges('chw'),
+            requestChanges('chw-boss'),
+            requestChanges('supervisor'),
+            requestChanges('bob'),
+          ]))
+          .then(([ chwChanges, chwBossChanges, supervisorChanges, bobChanges ]) => {
+            assertChangeIds(chwChanges,
+              'org.couchdb.user:chw',
+              'fixture:user:chw',
+              'fixture:chwville',
+              'clinic_patient',
+              'clinic_report',
+              'clinic_report_2');
+
+            assertChangeIds(chwBossChanges,
+              'org.couchdb.user:chw-boss',
+              'fixture:user:chw-boss',
+              'fixture:chw-bossville',
+              'fixture:chwville',
+              'health_center_patient',
+              'health_center_report',
+              'clinic_report',
+              'clinic_report_2'
+            );
+            assertChangeIds(supervisorChanges,
+              'org.couchdb.user:supervisor',
+              'fixture:user:supervisor',
+              'fixture:chw-bossville',
+              'fixture:managerville',
+              'fixture:clareville',
+              'fixture:steveville',
+              'fixture:bobville',
+              'PARENT_PLACE',
+              'health_center_report',
+              'clinic_report',
+              'clinic_report_2'
+              );
+
+            assertChangeIds(bobChanges,
+              'org.couchdb.user:bob',
+              'fixture:bobville',
+              'fixture:user:bob');
+          });
+      });
+    });
   });
 
   it('should not return reports about your place by someone above you in the hierarchy', () =>

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1179,10 +1179,21 @@ describe('changes handler', () => {
             parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
           }
         };
+        const bobReport = {
+          _id: 'bob_report',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'fixture:user:bob', needs_signoff: null },
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:bob',
+           parent: { _id:'fixture:bobville', parent: { _id: parentPlace._id }}
+          }
+        };
 
         return utils
           .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
-          .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport ]))
+          .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport, bobReport ]))
           .then(() => Promise.all([
             requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place
             requestChanges('chw-boss'), // chw-boss > chw-bossville > parent_place
@@ -1219,7 +1230,8 @@ describe('changes handler', () => {
             assertChangeIds(bobChanges,
               'org.couchdb.user:bob',
               'fixture:bobville',
-              'fixture:user:bob');
+              'fixture:user:bob',
+              'bob_report');
           });
       });
 
@@ -1257,10 +1269,21 @@ describe('changes handler', () => {
             parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
           }
         };
+        const bobReport = {
+          _id: 'bob_report',
+          type: 'data_record',
+          reported_date: 1,
+          fields: { patient_id: 'fixture:user:bob', needs_signoff: {} },
+          form: 'f',
+          contact: {
+            _id: 'fixture:user:bob',
+            parent: { _id:'fixture:bobville', parent: { _id: parentPlace._id }}
+          }
+        };
 
         return utils
           .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
-          .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport ]))
+          .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport, bobReport ]))
           .then(() => Promise.all([
             requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place
             requestChanges('chw-boss'), // chw-boss > chw-bossville > parent_place
@@ -1284,8 +1307,7 @@ describe('changes handler', () => {
               'health_center_patient',
               'health_center_report',
               'clinic_report',
-              'clinic_report_2'
-            );
+              'clinic_report_2');
             assertChangeIds(supervisorChanges,
               'org.couchdb.user:supervisor',
               'fixture:user:supervisor',
@@ -1297,13 +1319,14 @@ describe('changes handler', () => {
               'PARENT_PLACE',
               'health_center_report',
               'clinic_report',
-              'clinic_report_2'
-              );
+              'clinic_report_2',
+              'bob_report');
 
             assertChangeIds(bobChanges,
               'org.couchdb.user:bob',
               'fixture:bobville',
-              'fixture:user:bob');
+              'fixture:user:bob',
+              'bob_report');
           });
       });
     });

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -36,6 +36,12 @@ describe('view docs_by_replication_key', () => {
       _id: 'testuser',
       reported_date: 1,
       type: 'person',
+      parent: { _id: 'testuserplace' }
+    },
+    {
+      _id: 'testuserplace',
+      reported_date: 1,
+      type: 'clinic'
     },
     {
       _id: 'test_kujua_message',
@@ -131,6 +137,11 @@ describe('view docs_by_replication_key', () => {
           _id: 'testuser'
         }
       },
+    }, {
+      _id: 'needs_signoff_within_branch',
+      type: 'data_record',
+      contact: { _id: 'user1', parent: { _id: 'parent1', parent: { _id: 'testuserplace' }}},
+      fields: { patient_id: 'somepatient', needs_signoff: true },
     }
   ];
 
@@ -196,6 +207,18 @@ describe('view docs_by_replication_key', () => {
         contact: 'not_the_testuser',
         _deleted: true
       },
+    },
+    {
+      _id: 'needs_signoff_outside_branch',
+      type: 'data_record',
+      contact: { _id: 'user2', parent: { _id: 'parent2', parent: { _id: 'not_testuserplace', parent: {}}}},
+      fields: { patient_id: 'somepatient', needs_signoff: true },
+    },
+    {
+      _id: 'needs_signoff_within_branch_falsy',
+      type: 'data_record',
+      contact: { _id: 'user1', parent: { _id: 'parent1', parent: { _id: 'testuserplace' }}},
+      fields: { patient_id: 'somepatient', needs_signoff: false },
     }
   ];
 
@@ -283,11 +306,11 @@ describe('view docs_by_replication_key', () => {
         }
         console.log('…done');
 
-        getChanges(['_all', 'testuser', 'testplace', 'testpatient'])
+        getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace'])
           .then(docs => {
             docByPlaceIds = docs;
 
-            getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient'])
+            getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace'])
               .then(docs => {
                 docByPlaceIds_unassigned = docs;
                 done();
@@ -344,6 +367,12 @@ describe('view docs_by_replication_key', () => {
 
     it('Falls back to contact id when invalid patient', () => {
       expect(docByPlaceIds).toContain('report_with_invalid_patient_id');
+    });
+
+    it('should return data_records with needs_signoff from same branch', () => {
+      expect(docByPlaceIds).toContain('needs_signoff_within_branch');
+      expect(docByPlaceIds).not.toContain('needs_signoff_within_branch_falsy');
+      expect(docByPlaceIds).not.toContain('needs_signoff_outside_branch');
     });
   });
 


### PR DESCRIPTION
# Description

Updates `docs_by_replication_key` to emit every id in submitter lineage for reports marked with `needs_signoff`. 
Updates API authorization service to return unique allowed doc ids (due to reports now emitting multiple keys)

medic/medic#5485

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
