### PR TITLE
Patch messageformat to provide "default" plurals fn instead of errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -564,6 +564,9 @@ module.exports = function(grunt) {
 
             // patch enketo to always mark the /inputs group as relevant
             'patch webapp/node_modules/enketo-core/src/js/Form.js < webapp/patches/enketo-inputs-always-relevant.patch',
+
+            // patch messageformat to add a default plural function for languages not yet supported by make-plural #5705
+            'patch webapp/node_modules/messageformat/lib/plurals.js < webapp/patches/messageformat-default-plurals.patch',
           ];
           return patches.join(' && ');
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -337,7 +337,8 @@ module.exports = function(grunt) {
           'bootstrap-daterangepicker/**',
           'enketo-core/**',
           'font-awesome/**',
-          'moment/**',
+          'messageformat/**',
+          'moment/**'
         ],
         dest: 'webapp/node_modules_backup',
       },

--- a/tests/e2e/api/controllers/records.spec.js
+++ b/tests/e2e/api/controllers/records.spec.js
@@ -79,7 +79,7 @@ describe('Import Records', () => {
           a_number: 42,
           a_boolean: false,
           another_boolean: false,
-          an_optional_date: moment('2018-11-10').valueOf()
+          an_optional_date: moment.utc('2018-11-10').valueOf()
         });
         return utils.db.remove(doc);
       });
@@ -161,7 +161,7 @@ describe('Import Records', () => {
         });
         expect(doc.fields).to.deep.equal({
           a_number: 42,
-          an_optional_date: moment('2018-11-10').valueOf()
+          an_optional_date: moment.utc('2018-11-10').valueOf()
         });
         expect(doc.errors.length).to.equal(1);
         expect(doc.errors[0]).to.deep.equal({

--- a/webapp/patches/messageformat-default-plurals.patch
+++ b/webapp/patches/messageformat-default-plurals.patch
@@ -1,0 +1,33 @@
+*** ./webapp/node_modules/messageformat/lib/plurals.js	Sat Oct 26 10:15:00 1985
+--- ./webapp/node_modules/messageformat/lib/plurals2.js	Fri Jun  7 16:10:19 2019
+***************
+*** 23,34 ****
+    return fn;
+  }
+
+  function get(locale, noPluralKeyChecks) {
+    for (var l = locale; l; l = l.replace(/[-_]?[^-_]*$/, '')) {
+      var pf = plurals[l];
+      if (pf) return wrapPluralFunc(l, pf, noPluralKeyChecks)
+    }
+!   throw new Error('Localisation function not found for locale ' + JSON.stringify(locale));
+  }
+
+  function getAll(noPluralKeyChecks) {
+--- 23,38 ----
+    return fn;
+  }
+
++ function defaultPluralFunc() {
++   return 'other';
++ }
++
+  function get(locale, noPluralKeyChecks) {
+    for (var l = locale; l; l = l.replace(/[-_]?[^-_]*$/, '')) {
+      var pf = plurals[l];
+      if (pf) return wrapPluralFunc(l, pf, noPluralKeyChecks)
+    }
+!   return wrapPluralFunc(l, defaultPluralFunc, noPluralKeyChecks);
+  }
+
+  function getAll(noPluralKeyChecks) {

--- a/webapp/patches/messageformat-default-plurals.patch
+++ b/webapp/patches/messageformat-default-plurals.patch
@@ -1,5 +1,5 @@
 *** ./webapp/node_modules/messageformat/lib/plurals.js	Sat Oct 26 10:15:00 1985
---- ./webapp/node_modules/messageformat/lib/plurals2.js	Fri Jun  7 16:10:19 2019
+--- ./webapp/node_modules/messageformat/lib/plurals2.js	Mon Jun 10 10:10:19 2019
 ***************
 *** 23,34 ****
     return fn;
@@ -14,11 +14,12 @@
   }
 
   function getAll(noPluralKeyChecks) {
---- 23,38 ----
+--- 23,39 ----
     return fn;
   }
 
-+ function defaultPluralFunc() {
++ function defaultPluralFunc(n, ord) {
++   if (ord) return 'other';
 +   return 'other';
 + }
 +


### PR DESCRIPTION
# Description

Opting for the most basic `make-plural` function: 
https://github.com/eemeli/make-plural/blob/master/packages/plurals/umd/plurals.js#L1

medic/medic#5705

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
