### PR TITLE
Make 50 the minimum contact search limit

### DIFF
--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -1,6 +1,8 @@
 var _ = require('underscore'),
   scrollLoader = require('../modules/scroll-loader');
 
+const PAGE_SIZE = 50;
+
 (function() {
   'use strict';
 
@@ -85,7 +87,9 @@ var _ = require('underscore'),
 
     var _query = function(options) {
       options = options || {};
-      options.limit = options.limit || 50;
+      if (!options.limit || options.limit < PAGE_SIZE) {
+        options.limit = PAGE_SIZE;
+      }
 
       if (!options.silent) {
         $scope.loading = true;

--- a/webapp/src/js/controllers/reports.js
+++ b/webapp/src/js/controllers/reports.js
@@ -2,6 +2,8 @@ const _ = require('underscore'),
   scrollLoader = require('../modules/scroll-loader'),
   lineageFactory = require('@medic/lineage');
 
+const PAGE_SIZE = 50;
+
 angular
   .module('inboxControllers')
   .controller('ReportsCtrl', function(
@@ -222,7 +224,10 @@ angular
     };
 
     var query = function(opts) {
-      const options = _.extend({ limit: 50, hydrateContactNames: true }, opts);
+      const options = _.extend({ limit: PAGE_SIZE, hydrateContactNames: true }, opts);
+      if (options.limit < PAGE_SIZE) {
+        options.limit = PAGE_SIZE;
+      }
       if (!options.silent) {
         $scope.error = false;
         $scope.errorSyntax = false;
@@ -570,7 +575,7 @@ angular
           $scope.hasReports = liveList.count() > 0;
           setActionBarData();
         } else {
-          query({ silent: true, limit: Math.max(50, liveList.count()) });
+          query({ silent: true, limit: liveList.count() });
         }
       },
       filter: function(change) {

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -674,16 +674,16 @@ describe('Contacts controller', () => {
         facility_id: undefined,
       });
       const searchResult = { _id: 'search-result' };
-      searchResults = Array(10).fill(searchResult);
+      searchResults = Array(60).fill(searchResult);
 
       return createController()
         .getSetupPromiseForTesting({ scrollLoaderStub })
         .then(() => {
           const lhs = contactsLiveList.getList();
           changesCallback({});
-          assert.equal(lhs.length, 10);
+          assert.equal(lhs.length, 60);
           assert.deepInclude(searchService.args[1][2], {
-            limit: 10,
+            limit: 60,
             silent: true,
             withIds: false,
           });
@@ -692,15 +692,15 @@ describe('Contacts controller', () => {
 
     it('when refreshing list as non-admin, does modify limit #4085', () => {
       const searchResult = { _id: 'search-result' };
-      searchResults = Array(10).fill(searchResult);
+      searchResults = Array(60).fill(searchResult);
 
       return createController()
         .getSetupPromiseForTesting({ scrollLoaderStub })
         .then(() => {
           const lhs = contactsLiveList.getList();
-          assert.equal(lhs.length, 11);
+          assert.equal(lhs.length, 61);
           changesCallback({});
-          assert.equal(searchService.args[1][2].limit, 10);
+          assert.equal(searchService.args[1][2].limit, 60);
           assert.equal(searchService.args[1][2].skip, undefined);
         });
     });
@@ -844,13 +844,13 @@ describe('Contacts controller', () => {
         .then(() => {
           changesCallback({ doc: { _id: '123' } });
           assert.equal(searchService.callCount, 2);
-          assert.equal(searchService.args[1][2].limit, 2);
+          assert.equal(searchService.args[1][2].limit, 50); // 50 is the minimum size just in case it's a new contact at the end of the list
         });
     });
 
     it('when handling deletes, does not shorten the LiveList #4080', () => {
       const searchResult = { _id: 'search-result' };
-      searchResults = Array(30).fill(searchResult);
+      searchResults = Array(60).fill(searchResult);
 
       isAdmin = true;
       userSettings = KarmaUtils.promiseService(null, {
@@ -862,7 +862,7 @@ describe('Contacts controller', () => {
         .then(() => {
           deadListFind.returns(true);
           changesCallback({ deleted: true, doc: {} });
-          assert.equal(searchService.args[1][2].limit, 30);
+          assert.equal(searchService.args[1][2].limit, 60);
         });
     });
 
@@ -1211,7 +1211,7 @@ describe('Contacts controller', () => {
             return createController()
               .getSetupPromiseForTesting()
               .then(() => {
-                Array.apply(null, Array(5)).forEach((k, i) =>
+                Array.apply(null, Array(60)).forEach((k, i) =>
                   contactsLiveList.insert({ _id: i })
                 );
                 assert.equal(searchService.callCount, 1);
@@ -1228,7 +1228,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 60, withIds: false, silent: true, reuseExistingDom: true },
                       { displayLastVisitedDate: true, visitCountSettings: {} },
                       undefined,
                     ]);
@@ -1258,7 +1258,7 @@ describe('Contacts controller', () => {
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 5, withIds: true, silent: true, reuseExistingDom: true },
+                    { limit: 49, withIds: true, silent: true, reuseExistingDom: true },
                     {
                       displayLastVisitedDate: true,
                       visitCountSettings: {},
@@ -1271,7 +1271,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 49, withIds: false, silent: true, reuseExistingDom: true },
                       {
                         displayLastVisitedDate: true,
                         visitCountSettings: {},
@@ -1314,7 +1314,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 49, withIds: false, silent: true, reuseExistingDom: true },
                       { displayLastVisitedDate: true, visitCountSettings: {} },
                       undefined,
                     ]);
@@ -1343,7 +1343,7 @@ describe('Contacts controller', () => {
                   assert.deepEqual(searchService.args[1], [
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 5, withIds: true, silent: true, reuseExistingDom: true },
+                    { limit: 49, withIds: true, silent: true, reuseExistingDom: true },
                     {
                       displayLastVisitedDate: true,
                       visitCountSettings: {},
@@ -1356,7 +1356,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 49, withIds: false, silent: true, reuseExistingDom: true },
                       {
                         displayLastVisitedDate: true,
                         visitCountSettings: {},
@@ -1399,7 +1399,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[i], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 49, withIds: false, silent: true, reuseExistingDom: true },
                       {},
                       undefined,
                     ]);
@@ -1438,7 +1438,7 @@ describe('Contacts controller', () => {
                     assert.deepEqual(searchService.args[2], [
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 5, withIds: false, silent: true, reuseExistingDom: true },
+                      { limit: 49, withIds: false, silent: true, reuseExistingDom: true },
                       {},
                       undefined,
                     ]);


### PR DESCRIPTION
Limiting to the number of items in the livelist means if a new item
is added to the bottom of the list it won't be returned in the
search results.

medic/medic#5718

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
