### PR TITLE
Runs npm dedupe before packaging api and sentinel

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -391,7 +391,6 @@ module.exports = function(grunt) {
           .map(module =>
             [
               `cd ${module}`,
-              `rm -rf node_modules`,
               `npm dedupe`,
               `npm ci --production`,
               `npm pack`,
@@ -846,8 +845,8 @@ module.exports = function(grunt) {
   grunt.registerTask('build', 'Build the static resources', [
     'exec:clean-build-dir',
     'copy:ddocs',
-    'build-node-modules',
     'build-common',
+    'build-node-modules',
     'minify',
     'couch-compile:primary',
   ]);
@@ -966,7 +965,6 @@ module.exports = function(grunt) {
     'install-dependencies',
     'static-analysis',
     'build',
-    'build-admin',
     'mochaTest:api-integration',
     'unit',
     'exec:test-standard'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -535,13 +535,11 @@ module.exports = function(grunt) {
       },
       'shared-lib-unit': {
         cmd: () => {
-          return getSharedLibDirs()
-            .map(
-              lib =>
-                `echo Testing shared library: ${lib} &&
-                 (cd shared-libs/${lib} && npm ci && npm test)`
-            )
-            .join(' && ');
+          const sharedLibs = getSharedLibDirs();
+          return [
+            ...sharedLibs.map(lib => `(cd shared-libs/${lib} && npm ci)`),
+            ...sharedLibs.map(lib => `echo Testing shared library: ${lib} && (cd shared-libs/${lib} && npm test)`),
+          ].join(' && ');
         },
       },
       // To monkey patch a library...

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,6 +168,11 @@ module.exports = function(grunt) {
             'angular-translate-interpolation-messageformat': './webapp/node_modules/angular-translate/dist/angular-translate-interpolation-messageformat/angular-translate-interpolation-messageformat',
             'angular-translate-handler-log': './webapp/node_modules/angular-translate/dist/angular-translate-handler-log/angular-translate-handler-log',
             'moment': './webapp/node_modules/moment/moment',
+            'google-libphonenumber': './webapp/node_modules/google-libphonenumber',
+            'gsm': './webapp/node_modules/gsm',
+            'object-path': './webapp/node_modules/object-path',
+            'bikram-sambat': './webapp/node_modules/bikram-sambat',
+            '@medic/phone-number': './webapp/node_modules/@medic/phone-number'
           },
         },
       },
@@ -178,6 +183,11 @@ module.exports = function(grunt) {
           transform: ['browserify-ngannotate'],
           alias: {
             'angular-translate-interpolation-messageformat': './admin/node_modules/angular-translate/dist/angular-translate-interpolation-messageformat/angular-translate-interpolation-messageformat',
+            'google-libphonenumber': './admin/node_modules/google-libphonenumber',
+            'gsm': './admin/node_modules/gsm',
+            'object-path': './admin/node_modules/object-path',
+            'bikram-sambat': './admin/node_modules/bikram-sambat',
+            '@medic/phone-number': './admin/node_modules/@medic/phone-number'
           },
         },
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -392,6 +392,7 @@ module.exports = function(grunt) {
             [
               `cd ${module}`,
               `rm -rf node_modules`,
+              `npm dedupe`,
               `npm ci --production`,
               `npm pack`,
               `mv medic-*.tgz ../build/ddocs/medic/_attachments/`,

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,6 +31,7 @@
     "angular-translate": "^2.18.1",
     "angular-ui-bootstrap": "^2.5.6",
     "async": "^2.6.1",
+    "bikram-sambat": "^1.5.0",
     "bikram-sambat-bootstrap": "^1.4.2",
     "bootstrap": "^3.3.7",
     "bootstrap-daterangepicker": "^2.1.30",


### PR DESCRIPTION
# Description

Post https://github.com/medic/medic/issues/5694 , our `api` and `sentinel` bundled doubled in size because of lots of duplicated dependencies ( `npm pack` straight up copies the symlinked folders ). 
Running `npm dedupe` reduces our bundle sizes to what they were before.

| Version                                                                                                   | api    | sentinel | compiled.json |
|-----------------------------------------------------------------------------------------------------------|--------|----------|---------------|
| [3.5.x](https://staging.dev.medicmobile.org/_couch/_utils/document.html?builds/medic:medic:3.5.x)         | 3.7 MB | 2.9 MB   | 20.1 MB       |
| [master](https://staging.dev.medicmobile.org/_couch/_utils/document.html?builds/medic:medic:master)       | 7.9 MB | 6.5 MB   | 19.0 M        |
| [this PR](https://staging.dev.medicmobile.org/_couch/_utils/document.html?builds/medic:medic:test-dedupe) | 3.8 MB | 2.9 MB   | 19.0 M        |

medic/medic#5739

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
