### PR TITLE
Set initial_creation_date of infodocs to when they are first created

### DIFF
--- a/shared-libs/transitions/src/lib/infodoc.js
+++ b/shared-libs/transitions/src/lib/infodoc.js
@@ -41,7 +41,7 @@ const getInfoDoc = change => {
         doc.transitions = doc.transitions || change.doc.transitions || {};
         return doc;
       } else {
-        return createInfoDoc(change.id, 'unknown');
+        return createInfoDoc(change.id, new Date());
       }
     })
     .then(doc => updateInfoDoc(doc, rev));
@@ -129,7 +129,7 @@ const bulkGet = changes => {
     .then(result => {
       result.forEach(row => {
         if (!row.doc) {
-          infoDocs.push(createInfoDoc(getDocId(row.key), 'unknown'));
+          infoDocs.push(createInfoDoc(getDocId(row.key), new Date()));
         } else {
           row.doc.legacy = true;
           infoDocs.push(row.doc);

--- a/shared-libs/transitions/src/lib/infodoc.js
+++ b/shared-libs/transitions/src/lib/infodoc.js
@@ -41,18 +41,22 @@ const getInfoDoc = change => {
         doc.transitions = doc.transitions || change.doc.transitions || {};
         return doc;
       } else {
-        return createInfoDoc(change.id, new Date());
+        return createInfoDoc(change.doc._id, change.doc._rev);
       }
     })
     .then(doc => updateInfoDoc(doc, rev));
 };
 
-const createInfoDoc = (docId, initialReplicationDate) => {
+const createInfoDoc = (docId, docRev) => {
+  // either it hasn't been even saved yet (ie comes from SMS synchronous transition processing)
+  // or it has been saved once and is being picked up by sentinel.
+  const isInitialVersion = !docRev || docRev.startsWith('1-');
+
   return {
     _id: infoDocId(docId),
     type: 'info',
     doc_id: docId,
-    initial_replication_date: initialReplicationDate,
+    initial_replication_date: isInitialVersion ? new Date() : 'unknown',
   };
 };
 
@@ -129,7 +133,10 @@ const bulkGet = changes => {
     .then(result => {
       result.forEach(row => {
         if (!row.doc) {
-          infoDocs.push(createInfoDoc(getDocId(row.key), new Date()));
+          const mainDocId = getDocId(row.key);
+          const mainDoc = changes.find(change => change.id === mainDocId).doc;
+
+          infoDocs.push(createInfoDoc(mainDoc._id, mainDoc._rev));
         } else {
           row.doc.legacy = true;
           infoDocs.push(row.doc);

--- a/shared-libs/transitions/test/integration/transitions.js
+++ b/shared-libs/transitions/test/integration/transitions.js
@@ -217,7 +217,7 @@ describe('functional transitions', () => {
     });
 
     it('should throw infodoc errors', done => {
-      const doc = { _id: 'my_id', type: 'data_record', form: 'v' };
+      const doc = { _id: 'my_id', _rev: '1-abc', type: 'data_record', form: 'v' };
       sinon.stub(transitions._lineage, 'fetchHydratedDoc').resolves(doc);
       sinon.stub(db.sentinel, 'get')
         .resolves({})
@@ -253,6 +253,7 @@ describe('functional transitions', () => {
 
       const doc = {
         _id: 'my_id',
+        _rev: '1-abc',
         reported_date: new Date().valueOf()
       };
       sinon.stub(transitions._lineage, 'fetchHydratedDoc').resolves(doc);
@@ -289,6 +290,7 @@ describe('functional transitions', () => {
 
       const doc = {
         _id: 'my_id',
+        _rev: '1-abc',
         form: 'V',
         from: '123456',
         type: 'data_record',
@@ -338,6 +340,7 @@ describe('functional transitions', () => {
 
       const doc = {
         _id: 'my_id',
+        _rev: '1-abc',
         form: 'V',
         from: '123456',
         type: 'data_record',
@@ -409,7 +412,9 @@ describe('functional transitions', () => {
 
       const docs = [
         {
-          id: 'has alert', //intentionally not _id
+          id: 'has alert', // intentionally not _id, just used to identify the doc later in assertions
+                           // in this scenario these docs have not yet been saved to Couch, coming straight
+                           // from the SMS api
           form: 'V',
           from: 'phone1',
           type: 'data_record',

--- a/shared-libs/transitions/test/unit/lib/infodoc.js
+++ b/shared-libs/transitions/test/unit/lib/infodoc.js
@@ -95,17 +95,24 @@ describe('infodoc', () => {
     });
 
     it('should generate infodocs when all are new', () => {
-      const changes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+      const changes = [
+        { id: 'a', doc: {_id: 'a', _rev: '1-abc'}},
+        { id: 'b', doc: {_id: 'b', _rev: '1-abc'}},
+        { id: 'c', doc: {_id: 'c', _rev: '1-abc'}}
+      ];
 
       sinon.stub(db.sentinel, 'allDocs')
-        .resolves({ rows: changes.map(doc => ({ key: `${doc.id}-info`, error: 'not_found' }))});
+        .resolves({ rows: changes.map(change => ({ key: `${change.id}-info`, error: 'not_found' }))});
       sinon.stub(db.medic, 'allDocs')
-        .resolves({ rows: changes.map(doc => ({ key: `${doc.id}-info`, error: 'not_found' }))});
+        .resolves({ rows: changes.map(change => ({ key: `${change.id}-info`, error: 'not_found' }))});
 
       return infodoc.bulkGet(changes).then(result => {
         assert.deepInclude(result[0], { _id: 'a-info', type: 'info', doc_id: 'a' });
+        assert.ok(result[0].initial_replication_date instanceof Date);
         assert.deepInclude(result[1], { _id: 'b-info', type: 'info', doc_id: 'b' });
+        assert.ok(result[1].initial_replication_date instanceof Date);
         assert.deepInclude(result[2], { _id: 'c-info', type: 'info', doc_id: 'c' });
+        assert.ok(result[2].initial_replication_date instanceof Date);
 
         assert.equal(db.sentinel.allDocs.callCount, 1);
         assert.deepEqual(db.sentinel.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
@@ -114,8 +121,30 @@ describe('infodoc', () => {
       });
     });
 
+    it('sets the initial_replication_date to unknown if its not the first version', () => {
+      const changes = [
+        { id: 'a', doc: {_id: 'a', _rev: '2-abc'}},
+      ];
+
+      sinon.stub(db.sentinel, 'allDocs')
+        .resolves({ rows: changes.map(change => ({ key: `${change.id}-info`, error: 'not_found' }))});
+      sinon.stub(db.medic, 'allDocs')
+        .resolves({ rows: changes.map(change => ({ key: `${change.id}-info`, error: 'not_found' }))});
+
+      return infodoc.bulkGet(changes).then(result => {
+        assert.deepEqual(result, [{ _id: 'a-info', type: 'info', doc_id: 'a', initial_replication_date: 'unknown' }]);
+      });
+    });
+
     it('should work with a mix of all', () => {
-      const changes = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }, { id: 'f' }];
+      const changes = [
+        { id: 'a', doc: {_id: 'a', _rev: '1-abc' }},
+        { id: 'b', doc: {_id: 'b', _rev: '1-abc' }},
+        { id: 'c', doc: {_id: 'c', _rev: '1-abc' }},
+        { id: 'd', doc: {_id: 'd', _rev: '1-abc' }},
+        { id: 'e', doc: {_id: 'e', _rev: '1-abc' }},
+        { id: 'f', doc: {_id: 'f', _rev: '1-abc' }}
+      ];
 
       sinon.stub(db.sentinel, 'allDocs')
         .resolves({ rows: [

--- a/shared-libs/transitions/test/unit/lib/infodoc.js
+++ b/shared-libs/transitions/test/unit/lib/infodoc.js
@@ -103,11 +103,9 @@ describe('infodoc', () => {
         .resolves({ rows: changes.map(doc => ({ key: `${doc.id}-info`, error: 'not_found' }))});
 
       return infodoc.bulkGet(changes).then(result => {
-        assert.deepEqual(result, [
-          { _id: 'a-info', type: 'info', doc_id: 'a', initial_replication_date: 'unknown'},
-          { _id: 'b-info', type: 'info', doc_id: 'b', initial_replication_date: 'unknown' },
-          { _id: 'c-info', type: 'info', doc_id: 'c', initial_replication_date: 'unknown' }
-        ]);
+        assert.deepInclude(result[0], { _id: 'a-info', type: 'info', doc_id: 'a' });
+        assert.deepInclude(result[1], { _id: 'b-info', type: 'info', doc_id: 'b' });
+        assert.deepInclude(result[2], { _id: 'c-info', type: 'info', doc_id: 'c' });
 
         assert.equal(db.sentinel.allDocs.callCount, 1);
         assert.deepEqual(db.sentinel.allDocs.args[0], [{ keys: ['a-info', 'b-info', 'c-info'], include_docs: true }]);
@@ -137,14 +135,12 @@ describe('infodoc', () => {
           ]});
 
       return infodoc.bulkGet(changes).then(result => {
-        assert.deepEqual(result, [
-          { _id: 'a-info', _rev: 'a-r', doc_id: 'a' },
-          { _id: 'd-info', _rev: 'd-r', doc_id: 'd' },
-          { _id: 'b-info', _rev: 'b-r', doc_id: 'b', legacy: true },
-          { _id: 'c-info', doc_id: 'c', initial_replication_date: 'unknown', type: 'info' },
-          { _id: 'e-info', doc_id: 'e', initial_replication_date: 'unknown', type: 'info' },
-          { _id: 'f-info', _rev: 'f-r', doc_id: 'f', legacy: true },
-        ]);
+        assert.deepInclude(result[0], { _id: 'a-info', _rev: 'a-r', doc_id: 'a' });
+        assert.deepInclude(result[1], { _id: 'd-info', _rev: 'd-r', doc_id: 'd' });
+        assert.deepInclude(result[2], { _id: 'b-info', _rev: 'b-r', doc_id: 'b', legacy: true });
+        assert.deepInclude(result[3], { _id: 'c-info', doc_id: 'c', type: 'info' });
+        assert.deepInclude(result[4], { _id: 'e-info', doc_id: 'e', type: 'info' });
+        assert.deepInclude(result[5], { _id: 'f-info', _rev: 'f-r', doc_id: 'f', legacy: true });
 
         assert.equal(db.sentinel.allDocs.callCount, 1);
         assert.deepEqual(


### PR DESCRIPTION
This is not totally correct but is a less destabilising solution than a
more correct one.

For new documents the date will be off by however long it takes for
sentinel to catch up (which could be <1s).

For old documents that don't already have info docs the date will be
hilariously off.

A more correct solution would be to keep this code as is, and to create
infodocs in API when documents get PUT/POST/bulk_docs'ed

medic/medic#5760