### PR TITLE
Use loose-envify to stub out environment checks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -582,6 +582,17 @@ module.exports = function(grunt) {
       },
       audit: { cmd: 'node ./scripts/audit-all.js' },
       'audit-whitelist': { cmd: 'git diff $(cat .auditignore | git hash-object -w --stdin) $(node ./scripts/audit-all.js | git hash-object -w --stdin) --word-diff --exit-code' },
+      'envify': {
+        cmd: () => {
+          if (!TRAVIS_BUILD_NUMBER) {
+            return 'echo "Not building on Travis so not envifying"';
+          }
+          return 'mv build/ddocs/medic/_attachments/js/inbox.js inbox.tmp.js && ' +
+                 'NODE_ENV=production node node_modules/loose-envify/cli.js inbox.tmp.js > build/ddocs/medic/_attachments/js/inbox.js && ' +
+                 'rm inbox.tmp.js && ' +
+                 'echo "Envify complete"';
+        }
+      }
     },
     watch: {
       options: {
@@ -854,6 +865,7 @@ module.exports = function(grunt) {
     'exec:clean-build-dir',
     'copy:ddocs',
     'build-common',
+    'exec:envify',
     'build-node-modules',
     'minify',
     'couch-compile:primary',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6545,6 +6545,15 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma-mocha": "^1.3.0",
     "karma-ng-html2js-preprocessor": "^1.0.0",
     "karma-spec-reporter": "0.0.32",
+    "loose-envify": "^1.4.0",
     "mocha": "^5.2.0",
     "moment": "^2.22.2",
     "node-sass": "^4.10.0",


### PR DESCRIPTION
# Description

Puts redux in production mode for travis builds.

medic/medic#5767

The diff of running envify before minification:

```
<   if (process.env.NODE_ENV !== 'production') {
---
>   if ("production" !== 'production') {
178670c178670
<     if (process.env.NODE_ENV !== 'production') {
---
>     if ("production" !== 'production') {
178684c178684
<   if (process.env.NODE_ENV !== 'production') {
---
>   if ("production" !== 'production') {
178705c178705
<     if (process.env.NODE_ENV !== 'production') {
---
>     if ("production" !== 'production') {
178907c178907
< if (process.env.NODE_ENV !== 'production' && typeof isCrushed.name === 'string' && isCrushed.name !== 'isCrushed') {
---
> if ("production" !== 'production' && typeof isCrushed.name === 'string' && isCrushed.name !== 'isCrushed') {
```

I expect during minification these blocks will be removed as they are now unreachable.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
