### PR TITLE
Fixes bug with two conflicting auth attributes 

### DIFF
--- a/webapp/src/js/directives/auth.js
+++ b/webapp/src/js/directives/auth.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+const _ = require('underscore');
 
 angular.module('inboxDirectives').directive('mmAuth', function(
   $log,
@@ -8,71 +8,71 @@ angular.module('inboxDirectives').directive('mmAuth', function(
 ) {
   'use strict';
   'ngInject';
-  var link = function(scope, element, attributes) {
-    var promises = [];
-    if (attributes.mmAuth) {
-      promises.push(Auth(attributes.mmAuth.split(',')));
-    }
+  const link = function(scope, element, attributes) {
 
-    if (attributes.mmAuthOnline) {
-      promises.push(Auth.online($parse(attributes.mmAuthOnline)(scope)));
-    }
-
-    if (promises.length) {
-      element.addClass('hidden');
-      $q
-        .all(promises)
+    const updateVisibility = promises => {
+      return $q.all(promises)
         .then(function () {
           element.removeClass('hidden');
+          return true;
         })
         .catch(function (err) {
           if (err) {
             $log.error('Error checking authorization', err);
           }
           element.addClass('hidden');
-        });
-    }
-
-    var checkAuthAny = function() {
-      element.addClass('hidden');
-
-      var mmAuthAny = mmAuthAnyGetter(scope);
-      mmAuthAny = _.isArray(mmAuthAny) ? mmAuthAny : [mmAuthAny];
-
-      if (_.any(mmAuthAny, function(element) {
-        return element === true;
-      })) {
-        return element.removeClass('hidden');
-      }
-
-      var permissionsGroups = mmAuthAny
-        .filter(function(element) {
-          return _.isArray(element) || _.isString(element);
-        })
-        .map(function(element) {
-          return (_.isArray(element) && _.flatten(element)) || [ element ];
-        });
-
-      if (!permissionsGroups.length) {
-        return;
-      }
-
-      Auth
-        .any(permissionsGroups)
-        .then(function() {
-          element.removeClass('hidden');
-        })
-        .catch(function (err) {
-          if (err) {
-            $log.error('Error checking authorization', err);
-          }
-          element.addClass('hidden');
+          return false;
         });
     };
 
-    if (attributes.mmAuthAny) {
-      var mmAuthAnyGetter = $parse(attributes.mmAuthAny);
-      scope.$watch(mmAuthAnyGetter, checkAuthAny);
+    const staticChecks = () => {
+      const promises = [];
+      if (attributes.mmAuth) {
+        promises.push(Auth(attributes.mmAuth.split(',')));
+      }
+
+      if (attributes.mmAuthOnline) {
+        promises.push(Auth.online($parse(attributes.mmAuthOnline)(scope)));
+      }
+
+      if (!promises.length) {
+        return true;
+      }
+
+      return updateVisibility(promises);
+    };
+
+    const dynamicChecks = allowed => {
+      if (allowed && attributes.mmAuthAny) {
+        const mmAuthAnyGetter = $parse(attributes.mmAuthAny);
+        scope.$watch(mmAuthAnyGetter, () => {
+          let mmAuthAny = mmAuthAnyGetter(scope);
+          mmAuthAny = Array.isArray(mmAuthAny) ? mmAuthAny : [mmAuthAny];
+
+          if (mmAuthAny.some(element => element === true)) {
+            element.removeClass('hidden');
+            return;
+          }
+
+          const permissionsGroups = mmAuthAny
+            .filter(element => Array.isArray(element) || _.isString(element))
+            .map(element => (Array.isArray(element) && _.flatten(element)) || [ element ]);
+
+          if (!permissionsGroups.length) {
+            element.addClass('hidden');
+            return;
+          }
+
+          return updateVisibility([ Auth.any(permissionsGroups) ]);
+        });
+      }
+    };
+
+    const result = staticChecks();
+    if (result === true) {
+      dynamicChecks(true);
+    } else {
+      result().then(dynamicChecks);
     }
   };
   return {

--- a/webapp/src/js/directives/auth.js
+++ b/webapp/src/js/directives/auth.js
@@ -72,7 +72,7 @@ angular.module('inboxDirectives').directive('mmAuth', function(
     if (result === true) {
       dynamicChecks(true);
     } else {
-      result().then(dynamicChecks);
+      result.then(dynamicChecks);
     }
   };
   return {

--- a/webapp/tests/karma/unit/directives/auth.js
+++ b/webapp/tests/karma/unit/directives/auth.js
@@ -180,10 +180,10 @@ describe('auth directive', () => {
       const element2 = compile('<a mm-auth mm-auth-any="[false, false, false]">')(scope);
       scope.$digest();
       setTimeout(() => {
-          chai.expect(element.hasClass('hidden')).to.equal(true);
-          chai.expect(element2.hasClass('hidden')).to.equal(true);
-          chai.expect(Auth.any.callCount).to.equal(0);
-          done();
+        chai.expect(element.hasClass('hidden')).to.equal(true);
+        chai.expect(element2.hasClass('hidden')).to.equal(true);
+        chai.expect(Auth.any.callCount).to.equal(0);
+        done();
       });
     });
 

--- a/webapp/tests/karma/unit/directives/auth.js
+++ b/webapp/tests/karma/unit/directives/auth.js
@@ -1,32 +1,32 @@
-describe('auth directive', function() {
+describe('auth directive', () => {
 
   'use strict';
 
-  var compile,
-      scope,
-      Auth;
+  let compile;
+  let scope;
+  let Auth;
 
-  beforeEach(function() {
+  beforeEach(() => {
     module('inboxApp');
     module('inboxDirectives');
     Auth = sinon.stub();
     Auth.any = sinon.stub();
     Auth.online = sinon.stub();
-    module(function ($provide) {
+    module($provide => {
       $provide.value('Auth', Auth);
       $provide.value('$q', Q);
     });
-    inject(function(_$compile_, _$rootScope_) {
+    inject((_$compile_, _$rootScope_) => {
       compile = _$compile_;
       scope = _$rootScope_;
     });
   });
 
-  it('should be shown when auth does not error', function(done) {
+  it('should be shown when auth does not error', done => {
     Auth.returns(Promise.resolve());
-    var element = compile('<a mm-auth="can_do_stuff">')(scope);
+    const element = compile('<a mm-auth="can_do_stuff">')(scope);
     scope.$digest();
-    setTimeout(function() {
+    setTimeout(() => {
       chai.expect(element.hasClass('hidden')).to.equal(false);
       chai.expect(Auth.callCount).to.equal(1);
       chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
@@ -34,11 +34,11 @@ describe('auth directive', function() {
     });
   });
 
-  it('should be hidden when auth errors', function(done) {
+  it('should be hidden when auth errors', done => {
     Auth.returns(Promise.reject('boom'));
-    var element = compile('<a mm-auth="can_do_stuff">')(scope);
+    const element = compile('<a mm-auth="can_do_stuff">')(scope);
     scope.$digest();
-    setTimeout(function() {
+    setTimeout(() => {
       chai.expect(element.hasClass('hidden')).to.equal(true);
       chai.expect(Auth.callCount).to.equal(1);
       chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
@@ -46,11 +46,11 @@ describe('auth directive', function() {
     });
   });
 
-  it('splits comma separated permissions', function(done) {
+  it('splits comma separated permissions', done => {
     Auth.returns(Promise.resolve());
-    var element = compile('<a mm-auth="can_do_stuff,!can_not_do_stuff">')(scope);
+    const element = compile('<a mm-auth="can_do_stuff,!can_not_do_stuff">')(scope);
     scope.$digest();
-    setTimeout(function() {
+    setTimeout(() => {
       chai.expect(element.hasClass('hidden')).to.equal(false);
       chai.expect(Auth.callCount).to.equal(1);
       chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff', '!can_not_do_stuff']);
@@ -61,7 +61,7 @@ describe('auth directive', function() {
   describe('mmAuthOnline', () => {
     it('should be shown when auth does not error', (done) => {
       Auth.online.resolves();
-      var element = compile('<a mm-auth mm-auth-online="true">')(scope);
+      const element = compile('<a mm-auth mm-auth-online="true">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
@@ -73,7 +73,7 @@ describe('auth directive', function() {
 
     it('should be hidden when auth errors', (done) => {
       Auth.online.rejects({ some: 'err' });
-      var element = compile('<a mm-auth mm-auth-online="false">')(scope);
+      const element = compile('<a mm-auth mm-auth-online="false">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
@@ -85,7 +85,7 @@ describe('auth directive', function() {
 
     it('parses the attribute value', (done) => {
       Auth.online.resolves();
-      var element = compile('<a mm-auth mm-auth-online="1 + 2 + 3">')(scope);
+      const element = compile('<a mm-auth mm-auth-online="1 + 2 + 3">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
@@ -101,7 +101,7 @@ describe('auth directive', function() {
       Auth.resolves();
       Auth.online.resolves();
 
-      var element = compile('<a mm-auth="permission_to_have" mm-auth-online="true">')(scope);
+      const element = compile('<a mm-auth="permission_to_have" mm-auth-online="true">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
@@ -117,7 +117,7 @@ describe('auth directive', function() {
       Auth.rejects();
       Auth.online.resolves();
 
-      var element = compile('<a mm-auth="permission_to_have" mm-auth-online="false">')(scope);
+      const element = compile('<a mm-auth="permission_to_have" mm-auth-online="false">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
@@ -133,7 +133,7 @@ describe('auth directive', function() {
       Auth.resolves();
       Auth.online.rejects();
 
-      var element = compile('<a mm-auth="permission_to_have" mm-auth-online="true">')(scope);
+      const element = compile('<a mm-auth="permission_to_have" mm-auth-online="true">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
@@ -145,11 +145,23 @@ describe('auth directive', function() {
       });
     });
 
+    it('should be hidden when online fails and auth any succeeds', (done) => {
+      Auth.any.resolves();
+      Auth.online.rejects();
+
+      const element = compile('<a mm-auth mm-auth-any="[\'permission_to_have\', \'another_permission\']" mm-auth-online="true">')(scope);
+      scope.$digest();
+      setTimeout(() => {
+        chai.expect(element.hasClass('hidden')).to.equal(true);
+        done();
+      });
+    });
+
     it('should be hidden when both fail', (done) => {
       Auth.rejects();
       Auth.online.rejects();
 
-      var element = compile('<a mm-auth="permission_to_have" mm-auth-online="false">')(scope);
+      const element = compile('<a mm-auth="permission_to_have" mm-auth-online="false">')(scope);
       scope.$digest();
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
@@ -168,10 +180,10 @@ describe('auth directive', function() {
       const element2 = compile('<a mm-auth mm-auth-any="[false, false, false]">')(scope);
       scope.$digest();
       setTimeout(() => {
-        chai.expect(element.hasClass('hidden')).to.equal(true);
-        chai.expect(element2.hasClass('hidden')).to.equal(true);
-        chai.expect(Auth.any.callCount).to.equal(0);
-        done();
+          chai.expect(element.hasClass('hidden')).to.equal(true);
+          chai.expect(element2.hasClass('hidden')).to.equal(true);
+          chai.expect(Auth.any.callCount).to.equal(0);
+          done();
       });
     });
 


### PR DESCRIPTION
# Description

Previously if auth.online failed but auth.any passed the element
would be shown. Now both need to pass for the element to be shown.

#5464

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
