### PR TITLE
Wipe cache after unregistering service worker

### DIFF
--- a/tests/e2e/service-worker.js
+++ b/tests/e2e/service-worker.js
@@ -41,17 +41,15 @@ const doFetch = (path, headers) => browser.executeAsyncScript(async (innerPath, 
   });
 }, path, headers);
 
-const unregisterServiceWorker = () => browser.executeAsyncScript(async () => {
+const unregisterServiceWorkerAndWipeAllCaches = () => browser.executeAsyncScript(async () => {
   const callback = arguments[arguments.length - 1];
+
   const registrations = await navigator.serviceWorker.getRegistrations();
   registrations.forEach(registration => registration.unregister());
-  callback();
-});
 
-const wipeAllCaches = () => browser.executeAsyncScript(async () => {
-  const callback = arguments[arguments.length - 1];
   const cacheNames = await caches.keys();
   cacheNames.forEach(async (name) => await caches.delete(name));
+
   callback();
 });
 
@@ -114,9 +112,7 @@ describe('Service worker cache', () => {
       expect(resultingCachedUrls).to.deep.eq(initialCachedUrls);
     } finally {
       // since we've broken the cache. for sw registration
-      await unregisterServiceWorker();
-
-      await wipeAllCaches();
+      await unregisterServiceWorkerAndWipeAllCaches();
     }
   });
 });

--- a/tests/e2e/service-worker.js
+++ b/tests/e2e/service-worker.js
@@ -48,6 +48,13 @@ const unregisterServiceWorker = () => browser.executeAsyncScript(async () => {
   callback();
 });
 
+const wipeAllCaches = () => browser.executeAsyncScript(async () => {
+  const callback = arguments[arguments.length - 1];
+  const cacheNames = await caches.keys();
+  cacheNames.forEach(async (name) => await caches.delete(name));
+  callback();
+});
+
 describe('Service worker cache', () => {
   afterEach(utils.afterEach);
 
@@ -108,6 +115,8 @@ describe('Service worker cache', () => {
     } finally {
       // since we've broken the cache. for sw registration
       await unregisterServiceWorker();
+
+      await wipeAllCaches();
     }
   });
 });


### PR DESCRIPTION
# Description

Wipe cache after unregistering service worker

medic/medic#5783

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
