### PR TITLE
Allow mRDT Supervisor Tasks to resolve based on multiple needs_signoff reports

### DIFF
--- a/webapp/src/js/controllers/tasks-content.js
+++ b/webapp/src/js/controllers/tasks-content.js
@@ -87,7 +87,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
         XmlForm(action.form, { include_docs: true })
           .then(function(formDoc) {
             ctrl.setEnketoEditedStatus(false);
-            Enketo.render('#task-report', formDoc.id, action.content, markFormEdited)
+            return Enketo.render('#task-report', formDoc.id, action.content, markFormEdited)
               .then(function(formInstance) {
                 $scope.form = formInstance;
                 ctrl.loadingForm = false;

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -205,6 +205,10 @@ angular.module('inboxServices').service('Enketo',
       return LineageModelGenerator.contact(contact._id)
         .then(function(model) {
           return model.lineage;
+        })
+        .catch(function(err) {
+          $log.warn(`Failed to get lineage of contact: ${contact._id}`, err);
+          return [];
         });
     };
 

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -207,8 +207,12 @@ angular.module('inboxServices').service('Enketo',
           return model.lineage;
         })
         .catch(function(err) {
-          $log.warn(`Failed to get lineage of contact: ${contact._id}`, err);
-          return [];
+          if (err.code === 404) {
+            $log.warn(`Enketo failed to get lineage of contact '${contact._id}' because document does not exist`, err);
+            return [];
+          }
+
+          throw err;
         });
     };
 

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -56,17 +56,17 @@ var nools = require('nools'),
         return registrationUtils.getSubjectIds(contact).includes(id);
       };
 
-      var deriveFacts = function(dataRecords, contacts) {
-        var facts = _.map(contacts, function(contact) {
+      const deriveFacts = function(dataRecords, contacts) {
+        const facts = _.map(contacts, function(contact) {
           return new Contact({ contact: contact, reports: [] });
         });
         dataRecords.forEach(function(report) {
-          var factId = getContactId(report);
-          var fact = _.find(facts, function(fact) {
-            return contactHasId(fact.contact, factId);
-          });
+          const factId = getContactId(report);
+          const contact = factId ? { _id: factId } : undefined;
+          
+          let fact = _.find(facts, fact => contactHasId(fact.contact, factId));
           if (!fact) {
-            fact = new Contact({ contact: { _id: factId }, reports: [] });
+            fact = new Contact({ contact, reports: [] });
             facts.push(fact);
           }
           fact.reports.push(report);
@@ -249,7 +249,8 @@ var nools = require('nools'),
             })
             .catch(callback);
         },
-        _nools: nools // exposed for testing
+        _nools: nools, // exposed for testing
+        _getSession: () => session,
       };
     }
   );

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -62,10 +62,9 @@ var nools = require('nools'),
         });
         dataRecords.forEach(function(report) {
           const factId = getContactId(report);
-          const contact = factId ? { _id: factId } : undefined;
-          
           let fact = _.find(facts, fact => contactHasId(fact.contact, factId));
           if (!fact) {
+            const contact = factId ? { _id: factId } : undefined;
             fact = new Contact({ contact, reports: [] });
             facts.push(fact);
           }

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -66,7 +66,7 @@ var nools = require('nools'),
             return contactHasId(fact.contact, factId);
           });
           if (!fact) {
-            fact = new Contact({ reports: [] });
+            fact = new Contact({ contact: { _id: factId }, reports: [] });
             facts.push(fact);
           }
           fact.reports.push(report);

--- a/webapp/src/js/services/select2-search.js
+++ b/webapp/src/js/services/select2-search.js
@@ -142,7 +142,8 @@ angular.module('inboxServices').factory('Select2Search',
           } else {
             resolution = getDoc(value).then(function(doc) {
               selectEl.select2('data')[0].doc = doc;
-            });
+            })
+            .catch(err => $log.error('Select2 failed to get document', err));
           }
         }
 
@@ -187,7 +188,8 @@ angular.module('inboxServices').factory('Select2Search',
               getDoc(docId).then(function(doc) {
                 selectEl.select2('data')[0].doc = doc;
                 selectEl.trigger('change');
-              });
+              })
+              .catch(err => $log.error('Select2 failed to get document', err));
             }
           });
         }

--- a/webapp/src/js/services/select2-search.js
+++ b/webapp/src/js/services/select2-search.js
@@ -137,6 +137,9 @@ angular.module('inboxServices').factory('Select2Search',
           } else {
             resolution = getDoc(value).then(function(doc) {
               selectEl.select2('data')[0].doc = doc;
+            })
+            .catch(err => {
+              $log.warn('Unable to hydrate select2 selection', err);
             });
           }
         }
@@ -185,7 +188,7 @@ angular.module('inboxServices').factory('Select2Search',
                   selectEl.trigger('change');
                 })
                 .catch(function(err) {
-                  $log.error('Unable to hydrate select2 selection', err);
+                  $log.warn('Unable to hydrate select2 selection', err);
                 });
             }
           });

--- a/webapp/src/js/services/select2-search.js
+++ b/webapp/src/js/services/select2-search.js
@@ -101,11 +101,16 @@ angular.module('inboxServices').factory('Select2Search',
       var getDoc = function(id) {
         return LineageModelGenerator.contact(id, { merge: true })
           .then(function(contact) {
-            return contact && contact.doc;
+            contact.doc.muted = ContactMuted(contact.doc);
+            return contact.doc;
           })
-          .then(function(doc) {
-            doc.muted = ContactMuted(doc);
-            return doc;
+          .catch(err => {
+            if (err.code === 404) {
+              $log.warn('Unable to hydrate select2 document', err);
+              return undefined;
+            }
+
+            throw err;
           });
       };
 
@@ -137,9 +142,6 @@ angular.module('inboxServices').factory('Select2Search',
           } else {
             resolution = getDoc(value).then(function(doc) {
               selectEl.select2('data')[0].doc = doc;
-            })
-            .catch(err => {
-              $log.warn('Unable to hydrate select2 selection', err);
             });
           }
         }
@@ -182,14 +184,10 @@ angular.module('inboxServices').factory('Select2Search',
                         e.params.data.id;
 
             if (docId) {
-              getDoc(docId)
-                .then(function(doc) {
-                  selectEl.select2('data')[0].doc = doc;
-                  selectEl.trigger('change');
-                })
-                .catch(function(err) {
-                  $log.warn('Unable to hydrate select2 selection', err);
-                });
+              getDoc(docId).then(function(doc) {
+                selectEl.select2('data')[0].doc = doc;
+                selectEl.trigger('change');
+              });
             }
           });
         }

--- a/webapp/tests/karma/unit/controllers/tasks-content.js
+++ b/webapp/tests/karma/unit/controllers/tasks-content.js
@@ -1,5 +1,7 @@
-describe('TasksContentCtrl', function() {
-  var $scope,
+describe('TasksContentCtrl', () => {
+  const { expect } = chai;
+
+  let $scope,
       tasksActions,
       getEnketoEditedStatus,
       task,
@@ -14,20 +16,20 @@ describe('TasksContentCtrl', function() {
     KarmaUtils.setupMockStore();
   });
 
-  beforeEach(inject(function($controller, $ngRedux, TasksActions, Selectors) {
-    tasksActions = TasksActions($ngRedux.dispatch);
+  beforeEach(inject(($controller, $ngRedux, TasksActions, Selectors) => {
+    tasksActions = Actions($ngRedux.dispatch);
     render = sinon.stub();
     XmlForm = sinon.stub();
     $scope = {
-      $on: function() {},
-      $watch: function(prop, cb) {
+      $on: () => {},
+      $watch: (prop, cb) => {
         watchCallback = cb;
       },
       setSelected: () => tasksActions.setSelectedTask(task)
     };
     getEnketoEditedStatus = () => Selectors.getEnketoEditedStatus($ngRedux.getState());
-    render.returns(Promise.resolve());
-    createController = function() {
+    render.resolves();
+    createController = () => {
       ctrl = $controller('TasksContentCtrl', {
         $scope: $scope,
         $q: Q,
@@ -39,11 +41,11 @@ describe('TasksContentCtrl', function() {
     };
   }));
 
-  afterEach(function() {
+  afterEach(() => {
     KarmaUtils.restore(render, XmlForm);
   });
 
-  it('loads form when task has one action and no fields', function(done) {
+  it('loads form when task has one action and no fields', done => {
     task = {
       actions: [{
         type: 'report',
@@ -51,33 +53,33 @@ describe('TasksContentCtrl', function() {
         content: 'nothing'
       }]
     };
-    XmlForm.returns(Promise.resolve({ id: 'myform', doc: { title: 'My Form' } }));
+    XmlForm.resolves({ id: 'myform', doc: { title: 'My Form' } });
     createController();
     watchCallback();
-    chai.expect($scope.formId).to.equal('A');
-    setTimeout(function() {
-      chai.expect(render.callCount).to.equal(1);
-      chai.expect(render.getCall(0).args.length).to.equal(4);
-      chai.expect(render.getCall(0).args[0]).to.equal('#task-report');
-      chai.expect(render.getCall(0).args[1]).to.equal('myform');
-      chai.expect(render.getCall(0).args[2]).to.equal('nothing');
-      chai.expect(getEnketoEditedStatus()).to.equal(false);
+    expect($scope.formId).to.equal('A');
+    setTimeout(() => {
+      expect(render.callCount).to.equal(1);
+      expect(render.getCall(0).args.length).to.equal(4);
+      expect(render.getCall(0).args[0]).to.equal('#task-report');
+      expect(render.getCall(0).args[1]).to.equal('myform');
+      expect(render.getCall(0).args[2]).to.equal('nothing');
+      expect(getEnketoEditedStatus()).to.equal(false);
       done();
     });
   });
 
-  it('does not load form when task has more than one action', function(done) {
+  it('does not load form when task has more than one action', done => {
     task = {
       actions: [{}, {}] // two forms
     };
     createController();
-    chai.expect($scope.formId).to.equal(null);
-    chai.expect(ctrl.loadingForm).to.equal(undefined);
-    chai.expect(render.callCount).to.equal(0);
+    expect($scope.formId).to.equal(null);
+    expect(ctrl.loadingForm).to.equal(undefined);
+    expect(render.callCount).to.equal(0);
     done();
   });
 
-  it('does not load form when task has fields (e.g. description)', function(done) {
+  it('does not load form when task has fields (e.g. description)', done => {
     task = {
       actions: [{
         type: 'report',
@@ -95,14 +97,14 @@ describe('TasksContentCtrl', function() {
       }]
     };
     createController();
-    chai.expect($scope.formId).to.equal(null);
-    chai.expect(ctrl.loadingForm).to.equal(undefined);
-    chai.expect(render.callCount).to.equal(0);
+    expect($scope.formId).to.equal(null);
+    expect(ctrl.loadingForm).to.equal(undefined);
+    expect(render.callCount).to.equal(0);
     done();
   });
 
   it('displays error if enketo fails to render', done => {
-    render.returns(Promise.reject('foo'));
+    render.rejects('foo');
     task = {
       actions: [{
         type: 'report',
@@ -110,12 +112,12 @@ describe('TasksContentCtrl', function() {
         content: 'nothing'
       }]
     };
-    XmlForm.returns(Promise.resolve({ id: 'myform', doc: { title: 'My Form' } }));
+    XmlForm.resolves({ id: 'myform', doc: { title: 'My Form' } });
     createController();
     watchCallback();
-    setTimeout(function() {
-      chai.expect($scope.loadingForm).to.equal(false);
-      chai.expect($scope.contentError).to.equal(true);
+    setTimeout(() => {
+      expect(ctrl.loadingForm).to.equal(false);
+      expect($scope.contentError).to.equal(true);
       done();
     });
   });

--- a/webapp/tests/karma/unit/controllers/tasks-content.js
+++ b/webapp/tests/karma/unit/controllers/tasks-content.js
@@ -102,7 +102,7 @@ describe('TasksContentCtrl', function() {
   });
 
   it('displays error if enketo fails to render', done => {
-    render.throws('err');
+    render.returns(Promise.reject('foo'));
     task = {
       actions: [{
         type: 'report',

--- a/webapp/tests/karma/unit/controllers/tasks-content.js
+++ b/webapp/tests/karma/unit/controllers/tasks-content.js
@@ -17,7 +17,7 @@ describe('TasksContentCtrl', () => {
   });
 
   beforeEach(inject(($controller, $ngRedux, TasksActions, Selectors) => {
-    tasksActions = Actions($ngRedux.dispatch);
+    tasksActions = TasksActions($ngRedux.dispatch);
     render = sinon.stub();
     XmlForm = sinon.stub();
     $scope = {

--- a/webapp/tests/karma/unit/controllers/tasks-content.js
+++ b/webapp/tests/karma/unit/controllers/tasks-content.js
@@ -101,4 +101,22 @@ describe('TasksContentCtrl', function() {
     done();
   });
 
+  it('displays error if enketo fails to render', done => {
+    render.throws('err');
+    task = {
+      actions: [{
+        type: 'report',
+        form: 'A',
+        content: 'nothing'
+      }]
+    };
+    XmlForm.returns(Promise.resolve({ id: 'myform', doc: { title: 'My Form' } }));
+    createController();
+    watchCallback();
+    setTimeout(function() {
+      chai.expect($scope.loadingForm).to.equal(false);
+      chai.expect($scope.contentError).to.equal(true);
+      done();
+    });
+  });
 });

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -63,7 +63,7 @@ describe('Enketo service', () => {
     </model>`;
 
   let service,
-      Actions;
+      GlobalActions;
   const enketoInit = sinon.stub(),
       transform = sinon.stub(),
       dbGetAttachment = sinon.stub(),
@@ -86,8 +86,7 @@ describe('Enketo service', () => {
       EnketoPrepopulationData = sinon.stub(),
       XmlForm = sinon.stub(),
       Search = sinon.stub(),
-      LineageModelGenerator = { contact: sinon.stub() },
-      GlobalActions;
+      LineageModelGenerator = { contact: sinon.stub() };
 
   beforeEach(() => {
     module('inboxApp');

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -1,15 +1,15 @@
-describe('Enketo service', function() {
+describe('Enketo service', () => {
   'use strict';
 
   /** @return a mock form ready for putting in #dbContent */
-  var mockEnketoDoc = function(formInternalId) {
+  const mockEnketoDoc = formInternalId => {
     return {
       internalId: formInternalId,
       _attachments: { xml: { something: true } },
     };
   };
 
-  var VISIT_MODEL = `
+  const VISIT_MODEL = `
     <model>
       <instance>
         <data id="V" version="2015-06-05">
@@ -35,7 +35,7 @@ describe('Enketo service', function() {
       <bind nodeset="/data/name" type="string" required="true()" />
     </model>`;
 
-  var VISIT_MODEL_WITH_CONTACT_SUMMARY = `
+  const VISIT_MODEL_WITH_CONTACT_SUMMARY = `
     <model>
       <instance>
         <data id="V" version="2015-06-05">
@@ -62,8 +62,9 @@ describe('Enketo service', function() {
       <bind nodeset="/data/name" type="string" required="true()" />
     </model>`;
 
-  var service,
-      enketoInit = sinon.stub(),
+  let service,
+      Actions;
+  const enketoInit = sinon.stub(),
       transform = sinon.stub(),
       dbGetAttachment = sinon.stub(),
       dbGet = sinon.stub(),
@@ -88,17 +89,17 @@ describe('Enketo service', function() {
       LineageModelGenerator = { contact: sinon.stub() },
       GlobalActions;
 
-  beforeEach(function() {
+  beforeEach(() => {
     module('inboxApp');
 
     window.EnketoForm = EnketoForm;
     EnketoForm.returns({
       init: enketoInit,
-      calc: { update: function() {} },
-      output: { update: function() {} },
+      calc: { update: () => {} },
+      output: { update: () => {} },
     });
 
-    XmlForm.returns(Promise.resolve({ id: 'abc' }));
+    XmlForm.resolves({ id: 'abc' });
     GlobalActions = { setLastChangedDoc: sinon.stub() };
 
     module(function($provide) {
@@ -133,22 +134,22 @@ describe('Enketo service', function() {
     inject(function(_Enketo_) {
       service = _Enketo_;
     });
-    Language.returns(Promise.resolve('en'));
+    Language.resolves('en');
     TranslateFrom.returns('translated');
   });
 
-  afterEach(function() {
+  afterEach(() => {
     KarmaUtils.restore(EnketoForm, EnketoPrepopulationData, enketoInit, dbGetAttachment, dbGet, dbBulkDocs, transform, createObjectURL, ContactSummary, FileReader.utf8, Form2Sms, UserContact, form.validate, form.getDataStr, Language, TranslateFrom, AddAttachment, Search, LineageModelGenerator.contact);
     sinon.restore();
   });
 
-  describe('render', function() {
+  describe('render', () => {
 
     it('renders error when user does not have associated contact', function(done) {
-      UserContact.returns(Promise.resolve());
+      UserContact.resolves();
       service
         .render(null, 'not-defined')
-        .then(function() {
+        .then(() => {
           done(new Error('Should throw error'));
         })
         .catch(function(actual) {
@@ -159,17 +160,17 @@ describe('Enketo service', function() {
     });
 
     it('return error when form initialisation fails', function(done) {
-      UserContact.returns(Promise.resolve({ contact_id: '123' }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xml'));
+      UserContact.resolves({ contact_id: '123' });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xml');
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
-      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
-      var expected = [ 'nope', 'still nope' ];
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL);
+      EnketoPrepopulationData.resolves('<xml></xml>');
+      const expected = [ 'nope', 'still nope' ];
       enketoInit.returns(expected);
       service.render($('<div></div>'), 'ok')
-        .then(function() {
+        .then(() => {
           done(new Error('Should throw error'));
         })
         .catch(function(actual) {
@@ -179,17 +180,17 @@ describe('Enketo service', function() {
         });
     });
 
-    it('return form when everything works', function() {
-      UserContact.returns(Promise.resolve({ contact_id: '123' }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xmlblob'));
+    it('return form when everything works', () => {
+      UserContact.resolves({ contact_id: '123' });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves('<xml></xml>');
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
-      return service.render($('<div></div>'), 'ok').then(function() {
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL);
+      return service.render($('<div></div>'), 'ok').then(() => {
         chai.expect(UserContact.callCount).to.equal(1);
         chai.expect(EnketoPrepopulationData.callCount).to.equal(1);
         chai.expect(transform.callCount).to.equal(2);
@@ -201,23 +202,23 @@ describe('Enketo service', function() {
       });
     });
 
-    it('replaces img src with obj urls', function() {
-      UserContact.returns(Promise.resolve({ contact_id: '123' }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+    it('replaces img src with obj urls', () => {
+      UserContact.resolves({ contact_id: '123' });
+      dbGet.resolves(mockEnketoDoc('myform'));
       transform
-        .onFirstCall().returns(Promise.resolve('<div><img src="jr://myimg"></div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
+        .onFirstCall().resolves('<div><img src="jr://myimg"></div>')
+        .onSecondCall().resolves(VISIT_MODEL);
       dbGetAttachment
-        .onFirstCall().returns(Promise.resolve('xmlblob'))
-        .onSecondCall().returns(Promise.resolve('myobjblob'));
+        .onFirstCall().resolves('xmlblob')
+        .onSecondCall().resolves('myobjblob');
       createObjectURL.returns('myobjurl');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
-      var wrapper = $('<div><div class="container"></div><form></form></div>');
-      return service.render(wrapper, 'ok').then(function() {
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves('<xml></xml>');
+      const wrapper = $('<div><div class="container"></div><form></form></div>');
+      return service.render(wrapper, 'ok').then(() => {
         // need to wait for async get attachment to complete
-        var img = wrapper.find('img').first();
+        const img = wrapper.find('img').first();
         chai.expect(img.attr('src')).to.equal('myobjurl');
         chai.expect(img.css('visibility')).to.satisfy(function(val) {
           // different browsers return different values but both are equivalent
@@ -230,21 +231,21 @@ describe('Enketo service', function() {
       });
     });
 
-    it('leaves img wrapped if failed to load', function() {
-      UserContact.returns(Promise.resolve({ contact_id: '123' }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
+    it('leaves img wrapped if failed to load', () => {
+      UserContact.resolves({ contact_id: '123' });
+      dbGet.resolves(mockEnketoDoc('myform'));
       transform
-        .onFirstCall().returns(Promise.resolve('<div><img src="jr://myimg"></div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
+        .onFirstCall().resolves('<div><img src="jr://myimg"></div>')
+        .onSecondCall().resolves(VISIT_MODEL);
       dbGetAttachment
-        .onFirstCall().returns(Promise.resolve('xmlblob'))
-        .onSecondCall().returns(Promise.reject('not found'));
+        .onFirstCall().resolves('xmlblob')
+        .onSecondCall().rejects('not found');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve('<xml></xml>'));
-      var wrapper = $('<div><div class="container"></div><form></form></div>');
-      return service.render(wrapper, 'ok').then(function() {
-        var img = wrapper.find('img').first();
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves('<xml></xml>');
+      const wrapper = $('<div><div class="container"></div><form></form></div>');
+      return service.render(wrapper, 'ok').then(() => {
+        const img = wrapper.find('img').first();
         chai.expect(img.attr('src')).to.equal(undefined);
         chai.expect(img.attr('data-media-src')).to.equal('myimg');
         chai.expect(img.css('visibility')).to.equal('hidden');
@@ -255,68 +256,68 @@ describe('Enketo service', function() {
       });
     });
 
-    it('passes xml instance data through to Enketo', function() {
-      var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(Promise.resolve({ contact_id: '123' }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xmlblob'));
+    it('passes xml instance data through to Enketo', () => {
+      const data = '<data><patient_id>123</patient_id></data>';
+      UserContact.resolves({ contact_id: '123' });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve(data));
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves(data);
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve('my model'));
-      return service.render($('<div></div>'), 'ok', data).then(function() {
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves('my model');
+      return service.render($('<div></div>'), 'ok', data).then(() => {
         chai.expect(EnketoForm.callCount).to.equal(1);
         chai.expect(EnketoForm.args[0][1].modelStr).to.equal('my model');
         chai.expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
       });
     });
 
-    it('passes json instance data through to Enketo', function() {
-      var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(Promise.resolve({
+    it('passes json instance data through to Enketo', () => {
+      const data = '<data><patient_id>123</patient_id></data>';
+      UserContact.resolves({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
-      }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xmlblob'));
+      });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve(data));
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves(data);
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
-      var instanceData = {
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL);
+      const instanceData = {
         inputs: {
           patient_id: 123,
           name: 'sharon'
         }
       };
-      return service.render($('<div></div>'), 'ok', instanceData).then(function() {
+      return service.render($('<div></div>'), 'ok', instanceData).then(() => {
         chai.expect(EnketoForm.callCount).to.equal(1);
         chai.expect(EnketoForm.args[0][1].modelStr).to.equal(VISIT_MODEL);
         chai.expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
       });
     });
 
-    it('passes contact summary data to enketo', function() {
-      var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(Promise.resolve({
+    it('passes contact summary data to enketo', () => {
+      const data = '<data><patient_id>123</patient_id></data>';
+      UserContact.resolves({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
-      }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xmlblob'));
+      });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve(data));
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves(data);
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL_WITH_CONTACT_SUMMARY));
-      var instanceData = {
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL_WITH_CONTACT_SUMMARY);
+      const instanceData = {
         contact: {
           _id: 'fffff',
           patient_id: '44509'
@@ -326,13 +327,13 @@ describe('Enketo service', function() {
           name: 'sharon'
         }
       };
-      ContactSummary.returns(Promise.resolve({ context: { pregnant: true } }));
-      Search.returns(Promise.resolve([ { _id: 'somereport' }]));
-      LineageModelGenerator.contact.returns(Promise.resolve({ lineage: [ { _id: 'someparent' } ] }));
-      return service.render($('<div></div>'), 'ok', instanceData).then(function() {
+      ContactSummary.resolves({ context: { pregnant: true } });
+      Search.resolves([ { _id: 'somereport' }]);
+      LineageModelGenerator.contact.resolves({ lineage: [ { _id: 'someparent' } ] });
+      return service.render($('<div></div>'), 'ok', instanceData).then(() => {
         chai.expect(EnketoForm.callCount).to.equal(1);
         chai.expect(EnketoForm.args[0][1].external.length).to.equal(1);
-        var summary = EnketoForm.args[0][1].external[0];
+        const summary = EnketoForm.args[0][1].external[0];
         chai.expect(summary.id).to.equal('contact-summary');
         chai.expect(summary.xmlStr).to.equal('<context><pregnant>true</pregnant></context>');
         chai.expect(Search.callCount).to.equal(1);
@@ -349,22 +350,22 @@ describe('Enketo service', function() {
       });
     });
 
-    it('handles arrays and escaping characters', function() {
-      var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(Promise.resolve({
+    it('handles arrays and escaping characters', () => {
+      const data = '<data><patient_id>123</patient_id></data>';
+      UserContact.resolves({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
-      }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xmlblob'));
+      });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve(data));
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves(data);
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL_WITH_CONTACT_SUMMARY));
-      var instanceData = {
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL_WITH_CONTACT_SUMMARY);
+      const instanceData = {
         contact: {
           _id: 'fffff'
         },
@@ -373,18 +374,18 @@ describe('Enketo service', function() {
           name: 'sharon'
         }
       };
-      ContactSummary.returns(Promise.resolve({
+      ContactSummary.resolves({
         context: {
           pregnant: true,
           previousChildren: [ { dob: 2016 }, { dob: 2013 }, { dob: 2010 } ],
           notes: `always <uses> reserved "characters" & 'words'`
         }
-      }));
-      LineageModelGenerator.contact.returns(Promise.resolve({ lineage: [] }));
-      return service.render($('<div></div>'), 'ok', instanceData).then(function() {
+      });
+      LineageModelGenerator.contact.resolves({ lineage: [] });
+      return service.render($('<div></div>'), 'ok', instanceData).then(() => {
         chai.expect(EnketoForm.callCount).to.equal(1);
         chai.expect(EnketoForm.args[0][1].external.length).to.equal(1);
-        var summary = EnketoForm.args[0][1].external[0];
+        const summary = EnketoForm.args[0][1].external[0];
         chai.expect(summary.id).to.equal('contact-summary');
         chai.expect(summary.xmlStr).to.equal('<context><pregnant>true</pregnant><previousChildren><dob>2016</dob><dob>2013</dob><dob>2010</dob></previousChildren><notes>always &lt;uses&gt; reserved &quot;characters&quot; &amp; \'words\'</notes></context>');
         chai.expect(ContactSummary.callCount).to.equal(1);
@@ -392,22 +393,22 @@ describe('Enketo service', function() {
       });
     });
 
-    it('does not get contact summary when the form has no instance for it', function() {
-      var data = '<data><patient_id>123</patient_id></data>';
-      UserContact.returns(Promise.resolve({
+    it('does not get contact summary when the form has no instance for it', () => {
+      const data = '<data><patient_id>123</patient_id></data>';
+      UserContact.resolves({
         _id: '456',
         contact_id: '123',
         facility_id: '789'
-      }));
-      dbGet.returns(Promise.resolve(mockEnketoDoc('myform')));
-      dbGetAttachment.returns(Promise.resolve('xmlblob'));
+      });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
       enketoInit.returns([]);
-      FileReader.utf8.returns(Promise.resolve('<some-blob name="xml"/>'));
-      EnketoPrepopulationData.returns(Promise.resolve(data));
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves(data);
       transform
-        .onFirstCall().returns(Promise.resolve('<div>my form</div>'))
-        .onSecondCall().returns(Promise.resolve(VISIT_MODEL));
-      var instanceData = {
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL);
+      const instanceData = {
         contact: {
           _id: 'fffff'
         },
@@ -416,19 +417,51 @@ describe('Enketo service', function() {
           name: 'sharon'
         }
       };
-      return service.render($('<div></div>'), 'ok', instanceData).then(function() {
+      return service.render($('<div></div>'), 'ok', instanceData).then(() => {
         chai.expect(EnketoForm.callCount).to.equal(1);
         chai.expect(EnketoForm.args[0][1].external).to.equal(undefined);
         chai.expect(ContactSummary.callCount).to.equal(0);
         chai.expect(LineageModelGenerator.contact.callCount).to.equal(0);
       });
     });
+
+    it('ContactSummary receives empty lineage if contact doc is missing', () => {
+      LineageModelGenerator.contact.rejects({ code: 404 });
+
+      UserContact.resolves({
+        _id: '456',
+        contact_id: '123',
+        facility_id: '789'
+      });
+      dbGet.resolves(mockEnketoDoc('myform'));
+      dbGetAttachment.resolves('xmlblob');
+      enketoInit.returns([]);
+      FileReader.utf8.resolves('<some-blob name="xml"/>');
+      EnketoPrepopulationData.resolves('<data><patient_id>123</patient_id></data>');
+      transform
+        .onFirstCall().resolves('<div>my form</div>')
+        .onSecondCall().resolves(VISIT_MODEL_WITH_CONTACT_SUMMARY);
+      const instanceData = {
+        contact: {
+          _id: 'fffff',
+          patient_id: '44509'
+        }
+      };
+      ContactSummary.resolves({ context: { pregnant: true } });
+      Search.resolves([ { _id: 'somereport' }]);
+      return service.render($('<div></div>'), 'ok', instanceData).then(() => {
+        chai.expect(LineageModelGenerator.contact.callCount).to.equal(1);
+        chai.expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
+        chai.expect(ContactSummary.callCount).to.equal(1);
+        chai.expect(ContactSummary.args[0][2].length).to.equal(0);
+      });
+    });
   });
 
-  describe('save', function() {
+  describe('save', () => {
 
     it('rejects on invalid form', function(done) {
-      form.validate.returns(Promise.resolve(false));
+      form.validate.resolves(false);
       service.save('V', form).catch(function(actual) {
         chai.expect(actual.message).to.equal('Form is invalid');
         chai.expect(form.validate.callCount).to.equal(1);
@@ -436,14 +469,14 @@ describe('Enketo service', function() {
       });
     });
 
-    it('creates report', function() {
-      form.validate.returns(Promise.resolve(true));
-      var content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+    it('creates report', () => {
+      form.validate.resolves(true);
+      const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
       form.getDataStr.returns(content);
       dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
-      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
-      UserSettings.returns(Promise.resolve({ name: 'Jim' }));
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
+      UserSettings.resolves({ name: 'Jim' });
 
       return service.save('V', form).then(function(actual) {
         actual = actual[0];
@@ -471,18 +504,18 @@ describe('Enketo service', function() {
       });
     });
 
-    it('creates report with hidden fields', function() {
-      form.validate.returns(Promise.resolve(true));
-      var content =
+    it('creates report with hidden fields', () => {
+      form.validate.resolves(true);
+      const content =
         `<doc>
           <name>Sally</name>
           <lmp>10</lmp>
           <secret_code_name tag="hidden">S4L</secret_code_name>
         </doc>`;
       form.getDataStr.returns(content);
-      dbBulkDocs.returns(Promise.resolve([ { ok: true, id: '(generated-in-service)', rev: '1-abc' } ]));
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
-      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      dbBulkDocs.resolves([ { ok: true, id: '(generated-in-service)', rev: '1-abc' } ]);
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
       return service.save('V', form, null, null).then(function(actual) {
         actual = actual[0];
 
@@ -505,11 +538,11 @@ describe('Enketo service', function() {
       });
     });
 
-    it('updates report', function() {
-      form.validate.returns(Promise.resolve(true));
-      var content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+    it('updates report', () => {
+      form.validate.resolves(true);
+      const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
       form.getDataStr.returns(content);
-      dbGet.returns(Promise.resolve({
+      dbGet.resolves({
         _id: '6',
         _rev: '1-abc',
         form: 'V',
@@ -518,9 +551,9 @@ describe('Enketo service', function() {
         content_type: 'xml',
         type: 'data_record',
         reported_date: 500,
-      }));
-      dbBulkDocs.returns(Promise.resolve([ { ok: true, id: '6', rev: '2-abc' } ]));
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
+      });
+      dbBulkDocs.resolves([ { ok: true, id: '6', rev: '2-abc' } ]);
+      dbGetAttachment.resolves('<form/>');
       return service.save('V', form, null, '6').then(function(actual) {
         actual = actual[0];
 
@@ -547,12 +580,12 @@ describe('Enketo service', function() {
       });
     });
 
-    it('creates extra docs', function() {
+    it('creates extra docs', () => {
 
       const startTime = Date.now() - 1;
 
-      form.validate.returns(Promise.resolve(true));
-      var content =
+      form.validate.resolves(true);
+      const content =
           `<data>
             <name>Sally</name>
             <lmp>10</lmp>
@@ -572,8 +605,8 @@ describe('Enketo service', function() {
           return { ok: true, id: doc._id, rev: `1-${doc._id}-abc` };
         }));
       });
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
-      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
 
       return service.save('V', form, null, null).then(function(actual) {
         const endTime = Date.now() + 1;
@@ -585,7 +618,7 @@ describe('Enketo service', function() {
 
         chai.expect(actual.length).to.equal(3);
 
-        var actualReport = actual[0];
+        const actualReport = actual[0];
         chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
         chai.expect(actualReport._rev).to.equal(`1-${actualReport._id}-abc`);
         chai.expect(actualReport.fields.name).to.equal('Sally');
@@ -601,13 +634,13 @@ describe('Enketo service', function() {
         chai.expect(actualReport.fields.doc1).to.equal(undefined);
         chai.expect(actualReport.fields.doc2).to.equal(undefined);
 
-        var actualThing1 = actual[1];
+        const actualThing1 = actual[1];
         chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
         chai.expect(actualThing1._rev).to.equal(`1-${actualThing1._id}-abc`);
         chai.expect(actualThing1.reported_date).to.be.within(startTime, endTime);
         chai.expect(actualThing1.some_property_1).to.equal('some_value_1');
 
-        var actualThing2 = actual[2];
+        const actualThing2 = actual[2];
         chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
         chai.expect(actualThing2._rev).to.equal(`1-${actualThing2._id}-abc`);
         chai.expect(actualThing2.reported_date).to.be.within(startTime, endTime);
@@ -620,12 +653,12 @@ describe('Enketo service', function() {
       });
     });
 
-    it('creates extra docs with geolocation', function() {
+    it('creates extra docs with geolocation', () => {
 
       const startTime = Date.now() - 1;
 
-      form.validate.returns(Promise.resolve(true));
-      var content =
+      form.validate.resolves(true);
+      const content =
           `<data>
             <name>Sally</name>
             <lmp>10</lmp>
@@ -640,13 +673,13 @@ describe('Enketo service', function() {
             </doc2>
           </data>`;
       form.getDataStr.returns(content);
-      dbBulkDocs.returns(Promise.resolve([
+      dbBulkDocs.resolves([
         { ok: true, id: '6', rev: '1-abc' },
         { ok: true, id: '7', rev: '1-def' },
         { ok: true, id: '8', rev: '1-ghi' }
-      ]));
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
-      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      ]);
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
       return service.save('V', form, true).then(function(actual) {
         const endTime = Date.now() + 1;
 
@@ -657,7 +690,7 @@ describe('Enketo service', function() {
 
         chai.expect(actual.length).to.equal(3);
 
-        var actualReport = actual[0];
+        const actualReport = actual[0];
         chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
         chai.expect(actualReport.fields.name).to.equal('Sally');
         chai.expect(actualReport.fields.lmp).to.equal('10');
@@ -674,7 +707,7 @@ describe('Enketo service', function() {
 
         chai.expect(actualReport.geolocation).to.equal(true);
 
-        var actualThing1 = actual[1];
+        const actualThing1 = actual[1];
         chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
         chai.expect(actualThing1.reported_date).to.be.above(startTime);
         chai.expect(actualThing1.reported_date).to.be.below(endTime);
@@ -682,7 +715,7 @@ describe('Enketo service', function() {
 
         chai.expect(actualThing1.geolocation).to.equal(true);
 
-        var actualThing2 = actual[2];
+        const actualThing2 = actual[2];
         chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
         chai.expect(actualThing2.reported_date).to.be.above(startTime);
         chai.expect(actualThing2.reported_date).to.be.below(endTime);
@@ -694,9 +727,9 @@ describe('Enketo service', function() {
       });
     });
 
-    it('creates extra docs with references', function() {
-      form.validate.returns(Promise.resolve(true));
-      var content =
+    it('creates extra docs with references', () => {
+      form.validate.resolves(true);
+      const content =
           `<data>
             <name>Sally</name>
             <lmp>10</lmp>
@@ -720,13 +753,13 @@ describe('Enketo service', function() {
             <my_child_02 db-doc-ref="/data/doc2"/>
           </data>`;
       form.getDataStr.returns(content);
-      dbBulkDocs.returns(Promise.resolve([
+      dbBulkDocs.resolves([
         { ok: true, id: '6', rev: '1-abc' },
         { ok: true, id: '7', rev: '1-def' },
         { ok: true, id: '8', rev: '1-ghi' }
-      ]));
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
-      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      ]);
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
       return service.save('V', form).then(function(actual) {
         chai.expect(form.validate.callCount).to.equal(1);
         chai.expect(form.getDataStr.callCount).to.equal(1);
@@ -738,7 +771,7 @@ describe('Enketo service', function() {
         const doc1_id = actual[1]._id;
         const doc2_id = actual[2]._id;
 
-        var actualReport = actual[0];
+        const actualReport = actual[0];
         chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
         chai.expect(actualReport.fields.name).to.equal('Sally');
         chai.expect(actualReport.fields.lmp).to.equal('10');
@@ -756,14 +789,14 @@ describe('Enketo service', function() {
         chai.expect(actualReport.fields.doc1).to.equal(undefined);
         chai.expect(actualReport.fields.doc2).to.equal(undefined);
 
-        var actualThing1 = actual[1];
+        const actualThing1 = actual[1];
         chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
         chai.expect(actualThing1.some_property_1).to.equal('some_value_1');
         chai.expect(actualThing1.my_self_1).to.equal(doc1_id);
         chai.expect(actualThing1.my_parent_1).to.equal(reportId);
         chai.expect(actualThing1.my_sibling_1).to.equal(doc2_id);
 
-        var actualThing2 = actual[2];
+        const actualThing2 = actual[2];
         chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
         chai.expect(actualThing2.some_property_2).to.equal('some_value_2');
         chai.expect(actualThing2.my_self_2).to.equal(doc2_id);
@@ -774,9 +807,9 @@ describe('Enketo service', function() {
       });
     });
 
-    it('creates extra docs with repeats', function() {
-      form.validate.returns(Promise.resolve(true));
-      var content =
+    it('creates extra docs with repeats', () => {
+      form.validate.resolves(true);
+      const content =
           `<data xmlns:jr="http://openrosa.org/javarosa">
             <name>Sally</name>
             <lmp>10</lmp>
@@ -798,14 +831,14 @@ describe('Enketo service', function() {
             </repeat_doc>
           </data>`;
       form.getDataStr.returns(content);
-      dbBulkDocs.returns(Promise.resolve([
+      dbBulkDocs.resolves([
         { ok: true, id: '6', rev: '1-abc' },
         { ok: true, id: '7', rev: '1-def' },
         { ok: true, id: '8', rev: '1-ghi' },
         { ok: true, id: '9', rev: '1-ghi' }
-      ]));
-      dbGetAttachment.returns(Promise.resolve('<form/>'));
-      UserContact.returns(Promise.resolve({ _id: '123', phone: '555' }));
+      ]);
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
       return service.save('V', form).then(function(actual) {
         chai.expect(form.validate.callCount).to.equal(1);
         chai.expect(form.getDataStr.callCount).to.equal(1);
@@ -815,7 +848,7 @@ describe('Enketo service', function() {
         chai.expect(actual.length).to.equal(4);
         const reportId = actual[0]._id;
 
-        var actualReport = actual[0];
+        const actualReport = actual[0];
         chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
         chai.expect(actualReport.fields.name).to.equal('Sally');
         chai.expect(actualReport.fields.lmp).to.equal('10');
@@ -827,8 +860,8 @@ describe('Enketo service', function() {
         chai.expect(actualReport.from).to.equal('555');
         chai.expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
 
-        for (var i=1; i<=3; ++i) {
-          var repeatDocN = actual[i];
+        for (let i=1; i<=3; ++i) {
+          const repeatDocN = actual[i];
           chai.expect(repeatDocN._id).to.match(/(\w+-)\w+/);
           chai.expect(repeatDocN.my_parent).to.equal(reportId);
           chai.expect(repeatDocN.some_property).to.equal('some_value_'+i);

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -1,4 +1,6 @@
 describe('Enketo service', () => {
+  const { expect } = chai;
+
   'use strict';
 
   /** @return a mock form ready for putting in #dbContent */
@@ -152,8 +154,8 @@ describe('Enketo service', () => {
           done(new Error('Should throw error'));
         })
         .catch(function(actual) {
-          chai.expect(actual.message).to.equal('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
-          chai.expect(actual.translationKey).to.equal('error.loading.form.no_contact');
+          expect(actual.message).to.equal('Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.');
+          expect(actual.translationKey).to.equal('error.loading.form.no_contact');
           done();
         });
     });
@@ -173,8 +175,8 @@ describe('Enketo service', () => {
           done(new Error('Should throw error'));
         })
         .catch(function(actual) {
-          chai.expect(enketoInit.callCount).to.equal(1);
-          chai.expect(actual.message).to.equal(JSON.stringify(expected));
+          expect(enketoInit.callCount).to.equal(1);
+          expect(actual.message).to.equal(JSON.stringify(expected));
           done();
         });
     });
@@ -190,14 +192,14 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>my form</div>')
         .onSecondCall().resolves(VISIT_MODEL);
       return service.render($('<div></div>'), 'ok').then(() => {
-        chai.expect(UserContact.callCount).to.equal(1);
-        chai.expect(EnketoPrepopulationData.callCount).to.equal(1);
-        chai.expect(transform.callCount).to.equal(2);
-        chai.expect(transform.args[0][0]).to.equal('openrosa2html5form.xsl');
-        chai.expect(transform.args[1][0]).to.equal('openrosa2xmlmodel.xsl');
-        chai.expect(FileReader.utf8.callCount).to.equal(1);
-        chai.expect(FileReader.utf8.args[0][0]).to.equal('xmlblob');
-        chai.expect(enketoInit.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
+        expect(EnketoPrepopulationData.callCount).to.equal(1);
+        expect(transform.callCount).to.equal(2);
+        expect(transform.args[0][0]).to.equal('openrosa2html5form.xsl');
+        expect(transform.args[1][0]).to.equal('openrosa2xmlmodel.xsl');
+        expect(FileReader.utf8.callCount).to.equal(1);
+        expect(FileReader.utf8.args[0][0]).to.equal('xmlblob');
+        expect(enketoInit.callCount).to.equal(1);
       });
     });
 
@@ -218,15 +220,15 @@ describe('Enketo service', () => {
       return service.render(wrapper, 'ok').then(() => {
         // need to wait for async get attachment to complete
         const img = wrapper.find('img').first();
-        chai.expect(img.attr('src')).to.equal('myobjurl');
-        chai.expect(img.css('visibility')).to.satisfy(function(val) {
+        expect(img.attr('src')).to.equal('myobjurl');
+        expect(img.css('visibility')).to.satisfy(function(val) {
           // different browsers return different values but both are equivalent
           return val === '' || val === 'visible';
         });
-        chai.expect(transform.callCount).to.equal(2);
-        chai.expect(enketoInit.callCount).to.equal(1);
-        chai.expect(createObjectURL.callCount).to.equal(1);
-        chai.expect(createObjectURL.args[0][0]).to.equal('myobjblob');
+        expect(transform.callCount).to.equal(2);
+        expect(enketoInit.callCount).to.equal(1);
+        expect(createObjectURL.callCount).to.equal(1);
+        expect(createObjectURL.args[0][0]).to.equal('myobjblob');
       });
     });
 
@@ -245,13 +247,13 @@ describe('Enketo service', () => {
       const wrapper = $('<div><div class="container"></div><form></form></div>');
       return service.render(wrapper, 'ok').then(() => {
         const img = wrapper.find('img').first();
-        chai.expect(img.attr('src')).to.equal(undefined);
-        chai.expect(img.attr('data-media-src')).to.equal('myimg');
-        chai.expect(img.css('visibility')).to.equal('hidden');
-        chai.expect(img.closest('div').hasClass('loader')).to.equal(true);
-        chai.expect(transform.callCount).to.equal(2);
-        chai.expect(enketoInit.callCount).to.equal(1);
-        chai.expect(createObjectURL.callCount).to.equal(0);
+        expect(img.attr('src')).to.equal(undefined);
+        expect(img.attr('data-media-src')).to.equal('myimg');
+        expect(img.css('visibility')).to.equal('hidden');
+        expect(img.closest('div').hasClass('loader')).to.equal(true);
+        expect(transform.callCount).to.equal(2);
+        expect(enketoInit.callCount).to.equal(1);
+        expect(createObjectURL.callCount).to.equal(0);
       });
     });
 
@@ -267,9 +269,9 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>my form</div>')
         .onSecondCall().resolves('my model');
       return service.render($('<div></div>'), 'ok', data).then(() => {
-        chai.expect(EnketoForm.callCount).to.equal(1);
-        chai.expect(EnketoForm.args[0][1].modelStr).to.equal('my model');
-        chai.expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
+        expect(EnketoForm.callCount).to.equal(1);
+        expect(EnketoForm.args[0][1].modelStr).to.equal('my model');
+        expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
       });
     });
 
@@ -295,9 +297,9 @@ describe('Enketo service', () => {
         }
       };
       return service.render($('<div></div>'), 'ok', instanceData).then(() => {
-        chai.expect(EnketoForm.callCount).to.equal(1);
-        chai.expect(EnketoForm.args[0][1].modelStr).to.equal(VISIT_MODEL);
-        chai.expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
+        expect(EnketoForm.callCount).to.equal(1);
+        expect(EnketoForm.args[0][1].modelStr).to.equal(VISIT_MODEL);
+        expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
       });
     });
 
@@ -330,22 +332,22 @@ describe('Enketo service', () => {
       Search.resolves([ { _id: 'somereport' }]);
       LineageModelGenerator.contact.resolves({ lineage: [ { _id: 'someparent' } ] });
       return service.render($('<div></div>'), 'ok', instanceData).then(() => {
-        chai.expect(EnketoForm.callCount).to.equal(1);
-        chai.expect(EnketoForm.args[0][1].external.length).to.equal(1);
+        expect(EnketoForm.callCount).to.equal(1);
+        expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
-        chai.expect(summary.id).to.equal('contact-summary');
-        chai.expect(summary.xmlStr).to.equal('<context><pregnant>true</pregnant></context>');
-        chai.expect(Search.callCount).to.equal(1);
-        chai.expect(Search.args[0][0]).to.equal('reports');
-        chai.expect(Search.args[0][1].subjectIds).to.deep.equal(['fffff', '44509']);
-        chai.expect(LineageModelGenerator.contact.callCount).to.equal(1);
-        chai.expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
-        chai.expect(ContactSummary.callCount).to.equal(1);
-        chai.expect(ContactSummary.args[0][0]._id).to.equal('fffff');
-        chai.expect(ContactSummary.args[0][1].length).to.equal(1);
-        chai.expect(ContactSummary.args[0][1][0]._id).to.equal('somereport');
-        chai.expect(ContactSummary.args[0][2].length).to.equal(1);
-        chai.expect(ContactSummary.args[0][2][0]._id).to.equal('someparent');
+        expect(summary.id).to.equal('contact-summary');
+        expect(summary.xmlStr).to.equal('<context><pregnant>true</pregnant></context>');
+        expect(Search.callCount).to.equal(1);
+        expect(Search.args[0][0]).to.equal('reports');
+        expect(Search.args[0][1].subjectIds).to.deep.equal(['fffff', '44509']);
+        expect(LineageModelGenerator.contact.callCount).to.equal(1);
+        expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
+        expect(ContactSummary.callCount).to.equal(1);
+        expect(ContactSummary.args[0][0]._id).to.equal('fffff');
+        expect(ContactSummary.args[0][1].length).to.equal(1);
+        expect(ContactSummary.args[0][1][0]._id).to.equal('somereport');
+        expect(ContactSummary.args[0][2].length).to.equal(1);
+        expect(ContactSummary.args[0][2][0]._id).to.equal('someparent');
       });
     });
 
@@ -382,13 +384,13 @@ describe('Enketo service', () => {
       });
       LineageModelGenerator.contact.resolves({ lineage: [] });
       return service.render($('<div></div>'), 'ok', instanceData).then(() => {
-        chai.expect(EnketoForm.callCount).to.equal(1);
-        chai.expect(EnketoForm.args[0][1].external.length).to.equal(1);
+        expect(EnketoForm.callCount).to.equal(1);
+        expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
-        chai.expect(summary.id).to.equal('contact-summary');
-        chai.expect(summary.xmlStr).to.equal('<context><pregnant>true</pregnant><previousChildren><dob>2016</dob><dob>2013</dob><dob>2010</dob></previousChildren><notes>always &lt;uses&gt; reserved &quot;characters&quot; &amp; \'words\'</notes></context>');
-        chai.expect(ContactSummary.callCount).to.equal(1);
-        chai.expect(ContactSummary.args[0][0]._id).to.equal('fffff');
+        expect(summary.id).to.equal('contact-summary');
+        expect(summary.xmlStr).to.equal('<context><pregnant>true</pregnant><previousChildren><dob>2016</dob><dob>2013</dob><dob>2010</dob></previousChildren><notes>always &lt;uses&gt; reserved &quot;characters&quot; &amp; \'words\'</notes></context>');
+        expect(ContactSummary.callCount).to.equal(1);
+        expect(ContactSummary.args[0][0]._id).to.equal('fffff');
       });
     });
 
@@ -417,10 +419,10 @@ describe('Enketo service', () => {
         }
       };
       return service.render($('<div></div>'), 'ok', instanceData).then(() => {
-        chai.expect(EnketoForm.callCount).to.equal(1);
-        chai.expect(EnketoForm.args[0][1].external).to.equal(undefined);
-        chai.expect(ContactSummary.callCount).to.equal(0);
-        chai.expect(LineageModelGenerator.contact.callCount).to.equal(0);
+        expect(EnketoForm.callCount).to.equal(1);
+        expect(EnketoForm.args[0][1].external).to.equal(undefined);
+        expect(ContactSummary.callCount).to.equal(0);
+        expect(LineageModelGenerator.contact.callCount).to.equal(0);
       });
     });
 
@@ -449,10 +451,10 @@ describe('Enketo service', () => {
       ContactSummary.resolves({ context: { pregnant: true } });
       Search.resolves([ { _id: 'somereport' }]);
       return service.render($('<div></div>'), 'ok', instanceData).then(() => {
-        chai.expect(LineageModelGenerator.contact.callCount).to.equal(1);
-        chai.expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
-        chai.expect(ContactSummary.callCount).to.equal(1);
-        chai.expect(ContactSummary.args[0][2].length).to.equal(0);
+        expect(LineageModelGenerator.contact.callCount).to.equal(1);
+        expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
+        expect(ContactSummary.callCount).to.equal(1);
+        expect(ContactSummary.args[0][2].length).to.equal(0);
       });
     });
   });
@@ -462,8 +464,8 @@ describe('Enketo service', () => {
     it('rejects on invalid form', function(done) {
       form.validate.resolves(false);
       service.save('V', form).catch(function(actual) {
-        chai.expect(actual.message).to.equal('Form is invalid');
-        chai.expect(form.validate.callCount).to.equal(1);
+        expect(actual.message).to.equal('Form is invalid');
+        expect(form.validate.callCount).to.equal(1);
         done();
       });
     });
@@ -480,26 +482,26 @@ describe('Enketo service', () => {
       return service.save('V', form).then(function(actual) {
         actual = actual[0];
 
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(UserContact.callCount).to.equal(1);
-        chai.expect(actual._id).to.match(/(\w+-)\w+/);
-        chai.expect(actual._rev).to.equal('1-abc');
-        chai.expect(actual.fields.name).to.equal('Sally');
-        chai.expect(actual.fields.lmp).to.equal('10');
-        chai.expect(actual.form).to.equal('V');
-        chai.expect(actual.type).to.equal('data_record');
-        chai.expect(actual.content_type).to.equal('xml');
-        chai.expect(actual.contact._id).to.equal('123');
-        chai.expect(actual.from).to.equal('555');
-        chai.expect(dbGetAttachment.callCount).to.equal(1);
-        chai.expect(dbGetAttachment.args[0][0]).to.equal('abc');
-        chai.expect(AddAttachment.callCount).to.equal(1);
-        chai.expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
-        chai.expect(AddAttachment.args[0][1]).to.equal('content');
-        chai.expect(AddAttachment.args[0][2]).to.equal(content);
-        chai.expect(AddAttachment.args[0][3]).to.equal('application/xml');
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
+        expect(actual._id).to.match(/(\w+-)\w+/);
+        expect(actual._rev).to.equal('1-abc');
+        expect(actual.fields.name).to.equal('Sally');
+        expect(actual.fields.lmp).to.equal('10');
+        expect(actual.form).to.equal('V');
+        expect(actual.type).to.equal('data_record');
+        expect(actual.content_type).to.equal('xml');
+        expect(actual.contact._id).to.equal('123');
+        expect(actual.from).to.equal('555');
+        expect(dbGetAttachment.callCount).to.equal(1);
+        expect(dbGetAttachment.args[0][0]).to.equal('abc');
+        expect(AddAttachment.callCount).to.equal(1);
+        expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
+        expect(AddAttachment.args[0][1]).to.equal('content');
+        expect(AddAttachment.args[0][2]).to.equal(content);
+        expect(AddAttachment.args[0][3]).to.equal('application/xml');
       });
     });
 
@@ -518,22 +520,22 @@ describe('Enketo service', () => {
       return service.save('V', form, null, null).then(function(actual) {
         actual = actual[0];
 
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(UserContact.callCount).to.equal(1);
-        chai.expect(actual._id).to.match(/(\w+-)\w+/);
-        chai.expect(actual.fields.name).to.equal('Sally');
-        chai.expect(actual.fields.lmp).to.equal('10');
-        chai.expect(actual.fields.secret_code_name).to.equal('S4L');
-        chai.expect(actual.form).to.equal('V');
-        chai.expect(actual.type).to.equal('data_record');
-        chai.expect(actual.content_type).to.equal('xml');
-        chai.expect(actual.contact._id).to.equal('123');
-        chai.expect(actual.from).to.equal('555');
-        chai.expect(actual.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
-        chai.expect(GlobalActions.setLastChangedDoc.callCount).to.equal(1);
-        chai.expect(GlobalActions.setLastChangedDoc.args[0]).to.deep.equal([actual]);
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
+        expect(actual._id).to.match(/(\w+-)\w+/);
+        expect(actual.fields.name).to.equal('Sally');
+        expect(actual.fields.lmp).to.equal('10');
+        expect(actual.fields.secret_code_name).to.equal('S4L');
+        expect(actual.form).to.equal('V');
+        expect(actual.type).to.equal('data_record');
+        expect(actual.content_type).to.equal('xml');
+        expect(actual.contact._id).to.equal('123');
+        expect(actual.from).to.equal('555');
+        expect(actual.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
+        expect(GlobalActions.setLastChangedDoc.callCount).to.equal(1);
+        expect(GlobalActions.setLastChangedDoc.args[0]).to.deep.equal([actual]);
       });
     });
 
@@ -556,26 +558,26 @@ describe('Enketo service', () => {
       return service.save('V', form, null, '6').then(function(actual) {
         actual = actual[0];
 
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbGet.callCount).to.equal(1);
-        chai.expect(dbGet.args[0][0]).to.equal('6');
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(actual._id).to.equal('6');
-        chai.expect(actual._rev).to.equal('2-abc');
-        chai.expect(actual.fields.name).to.equal('Sally');
-        chai.expect(actual.fields.lmp).to.equal('10');
-        chai.expect(actual.form).to.equal('V');
-        chai.expect(actual.type).to.equal('data_record');
-        chai.expect(actual.reported_date).to.equal(500);
-        chai.expect(actual.content_type).to.equal('xml');
-        chai.expect(AddAttachment.callCount).to.equal(1);
-        chai.expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
-        chai.expect(AddAttachment.args[0][1]).to.equal('content');
-        chai.expect(AddAttachment.args[0][2]).to.equal(content);
-        chai.expect(AddAttachment.args[0][3]).to.equal('application/xml');
-        chai.expect(GlobalActions.setLastChangedDoc.callCount).to.equal(1);
-        chai.expect(GlobalActions.setLastChangedDoc.args[0]).to.deep.equal([actual]);
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbGet.callCount).to.equal(1);
+        expect(dbGet.args[0][0]).to.equal('6');
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(actual._id).to.equal('6');
+        expect(actual._rev).to.equal('2-abc');
+        expect(actual.fields.name).to.equal('Sally');
+        expect(actual.fields.lmp).to.equal('10');
+        expect(actual.form).to.equal('V');
+        expect(actual.type).to.equal('data_record');
+        expect(actual.reported_date).to.equal(500);
+        expect(actual.content_type).to.equal('xml');
+        expect(AddAttachment.callCount).to.equal(1);
+        expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
+        expect(AddAttachment.args[0][1]).to.equal('content');
+        expect(AddAttachment.args[0][2]).to.equal(content);
+        expect(AddAttachment.args[0][3]).to.equal('application/xml');
+        expect(GlobalActions.setLastChangedDoc.callCount).to.equal(1);
+        expect(GlobalActions.setLastChangedDoc.args[0]).to.deep.equal([actual]);
       });
     });
 
@@ -610,45 +612,45 @@ describe('Enketo service', () => {
       return service.save('V', form, null, null).then(function(actual) {
         const endTime = Date.now() + 1;
 
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(UserContact.callCount).to.equal(1);
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
 
-        chai.expect(actual.length).to.equal(3);
+        expect(actual.length).to.equal(3);
 
         const actualReport = actual[0];
-        chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualReport._rev).to.equal(`1-${actualReport._id}-abc`);
-        chai.expect(actualReport.fields.name).to.equal('Sally');
-        chai.expect(actualReport.fields.lmp).to.equal('10');
-        chai.expect(actualReport.fields.secret_code_name).to.equal('S4L');
-        chai.expect(actualReport.form).to.equal('V');
-        chai.expect(actualReport.type).to.equal('data_record');
-        chai.expect(actualReport.content_type).to.equal('xml');
-        chai.expect(actualReport.contact._id).to.equal('123');
-        chai.expect(actualReport.from).to.equal('555');
-        chai.expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
+        expect(actualReport._id).to.match(/(\w+-)\w+/);
+        expect(actualReport._rev).to.equal(`1-${actualReport._id}-abc`);
+        expect(actualReport.fields.name).to.equal('Sally');
+        expect(actualReport.fields.lmp).to.equal('10');
+        expect(actualReport.fields.secret_code_name).to.equal('S4L');
+        expect(actualReport.form).to.equal('V');
+        expect(actualReport.type).to.equal('data_record');
+        expect(actualReport.content_type).to.equal('xml');
+        expect(actualReport.contact._id).to.equal('123');
+        expect(actualReport.from).to.equal('555');
+        expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
 
-        chai.expect(actualReport.fields.doc1).to.equal(undefined);
-        chai.expect(actualReport.fields.doc2).to.equal(undefined);
+        expect(actualReport.fields.doc1).to.equal(undefined);
+        expect(actualReport.fields.doc2).to.equal(undefined);
 
         const actualThing1 = actual[1];
-        chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualThing1._rev).to.equal(`1-${actualThing1._id}-abc`);
-        chai.expect(actualThing1.reported_date).to.be.within(startTime, endTime);
-        chai.expect(actualThing1.some_property_1).to.equal('some_value_1');
+        expect(actualThing1._id).to.match(/(\w+-)\w+/);
+        expect(actualThing1._rev).to.equal(`1-${actualThing1._id}-abc`);
+        expect(actualThing1.reported_date).to.be.within(startTime, endTime);
+        expect(actualThing1.some_property_1).to.equal('some_value_1');
 
         const actualThing2 = actual[2];
-        chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualThing2._rev).to.equal(`1-${actualThing2._id}-abc`);
-        chai.expect(actualThing2.reported_date).to.be.within(startTime, endTime);
-        chai.expect(actualThing2.some_property_2).to.equal('some_value_2');
+        expect(actualThing2._id).to.match(/(\w+-)\w+/);
+        expect(actualThing2._rev).to.equal(`1-${actualThing2._id}-abc`);
+        expect(actualThing2.reported_date).to.be.within(startTime, endTime);
+        expect(actualThing2.some_property_2).to.equal('some_value_2');
 
-        chai.expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
+        expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
 
-        chai.expect(GlobalActions.setLastChangedDoc.callCount).to.equal(1);
-        chai.expect(GlobalActions.setLastChangedDoc.args[0]).to.deep.equal([actualReport]);
+        expect(GlobalActions.setLastChangedDoc.callCount).to.equal(1);
+        expect(GlobalActions.setLastChangedDoc.args[0]).to.deep.equal([actualReport]);
       });
     });
 
@@ -682,47 +684,47 @@ describe('Enketo service', () => {
       return service.save('V', form, true).then(function(actual) {
         const endTime = Date.now() + 1;
 
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(UserContact.callCount).to.equal(1);
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
 
-        chai.expect(actual.length).to.equal(3);
+        expect(actual.length).to.equal(3);
 
         const actualReport = actual[0];
-        chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualReport.fields.name).to.equal('Sally');
-        chai.expect(actualReport.fields.lmp).to.equal('10');
-        chai.expect(actualReport.fields.secret_code_name).to.equal('S4L');
-        chai.expect(actualReport.form).to.equal('V');
-        chai.expect(actualReport.type).to.equal('data_record');
-        chai.expect(actualReport.content_type).to.equal('xml');
-        chai.expect(actualReport.contact._id).to.equal('123');
-        chai.expect(actualReport.from).to.equal('555');
-        chai.expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
+        expect(actualReport._id).to.match(/(\w+-)\w+/);
+        expect(actualReport.fields.name).to.equal('Sally');
+        expect(actualReport.fields.lmp).to.equal('10');
+        expect(actualReport.fields.secret_code_name).to.equal('S4L');
+        expect(actualReport.form).to.equal('V');
+        expect(actualReport.type).to.equal('data_record');
+        expect(actualReport.content_type).to.equal('xml');
+        expect(actualReport.contact._id).to.equal('123');
+        expect(actualReport.from).to.equal('555');
+        expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
 
-        chai.expect(actualReport.fields.doc1).to.equal(undefined);
-        chai.expect(actualReport.fields.doc2).to.equal(undefined);
+        expect(actualReport.fields.doc1).to.equal(undefined);
+        expect(actualReport.fields.doc2).to.equal(undefined);
 
-        chai.expect(actualReport.geolocation).to.equal(true);
+        expect(actualReport.geolocation).to.equal(true);
 
         const actualThing1 = actual[1];
-        chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualThing1.reported_date).to.be.above(startTime);
-        chai.expect(actualThing1.reported_date).to.be.below(endTime);
-        chai.expect(actualThing1.some_property_1).to.equal('some_value_1');
+        expect(actualThing1._id).to.match(/(\w+-)\w+/);
+        expect(actualThing1.reported_date).to.be.above(startTime);
+        expect(actualThing1.reported_date).to.be.below(endTime);
+        expect(actualThing1.some_property_1).to.equal('some_value_1');
 
-        chai.expect(actualThing1.geolocation).to.equal(true);
+        expect(actualThing1.geolocation).to.equal(true);
 
         const actualThing2 = actual[2];
-        chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualThing2.reported_date).to.be.above(startTime);
-        chai.expect(actualThing2.reported_date).to.be.below(endTime);
-        chai.expect(actualThing2.some_property_2).to.equal('some_value_2');
+        expect(actualThing2._id).to.match(/(\w+-)\w+/);
+        expect(actualThing2.reported_date).to.be.above(startTime);
+        expect(actualThing2.reported_date).to.be.below(endTime);
+        expect(actualThing2.some_property_2).to.equal('some_value_2');
 
-        chai.expect(actualThing2.geolocation).to.equal(true);
+        expect(actualThing2.geolocation).to.equal(true);
 
-        chai.expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
+        expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
       });
     });
 
@@ -760,49 +762,49 @@ describe('Enketo service', () => {
       dbGetAttachment.resolves('<form/>');
       UserContact.resolves({ _id: '123', phone: '555' });
       return service.save('V', form).then(function(actual) {
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(UserContact.callCount).to.equal(1);
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
 
-        chai.expect(actual.length).to.equal(3);
+        expect(actual.length).to.equal(3);
         const reportId = actual[0]._id;
         const doc1_id = actual[1]._id;
         const doc2_id = actual[2]._id;
 
         const actualReport = actual[0];
-        chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualReport.fields.name).to.equal('Sally');
-        chai.expect(actualReport.fields.lmp).to.equal('10');
-        chai.expect(actualReport.fields.secret_code_name).to.equal('S4L');
-        chai.expect(actualReport.fields.my_self_0).to.equal(reportId);
-        chai.expect(actualReport.fields.my_child_01).to.equal(doc1_id);
-        chai.expect(actualReport.fields.my_child_02).to.equal(doc2_id);
-        chai.expect(actualReport.form).to.equal('V');
-        chai.expect(actualReport.type).to.equal('data_record');
-        chai.expect(actualReport.content_type).to.equal('xml');
-        chai.expect(actualReport.contact._id).to.equal('123');
-        chai.expect(actualReport.from).to.equal('555');
-        chai.expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
+        expect(actualReport._id).to.match(/(\w+-)\w+/);
+        expect(actualReport.fields.name).to.equal('Sally');
+        expect(actualReport.fields.lmp).to.equal('10');
+        expect(actualReport.fields.secret_code_name).to.equal('S4L');
+        expect(actualReport.fields.my_self_0).to.equal(reportId);
+        expect(actualReport.fields.my_child_01).to.equal(doc1_id);
+        expect(actualReport.fields.my_child_02).to.equal(doc2_id);
+        expect(actualReport.form).to.equal('V');
+        expect(actualReport.type).to.equal('data_record');
+        expect(actualReport.content_type).to.equal('xml');
+        expect(actualReport.contact._id).to.equal('123');
+        expect(actualReport.from).to.equal('555');
+        expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
 
-        chai.expect(actualReport.fields.doc1).to.equal(undefined);
-        chai.expect(actualReport.fields.doc2).to.equal(undefined);
+        expect(actualReport.fields.doc1).to.equal(undefined);
+        expect(actualReport.fields.doc2).to.equal(undefined);
 
         const actualThing1 = actual[1];
-        chai.expect(actualThing1._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualThing1.some_property_1).to.equal('some_value_1');
-        chai.expect(actualThing1.my_self_1).to.equal(doc1_id);
-        chai.expect(actualThing1.my_parent_1).to.equal(reportId);
-        chai.expect(actualThing1.my_sibling_1).to.equal(doc2_id);
+        expect(actualThing1._id).to.match(/(\w+-)\w+/);
+        expect(actualThing1.some_property_1).to.equal('some_value_1');
+        expect(actualThing1.my_self_1).to.equal(doc1_id);
+        expect(actualThing1.my_parent_1).to.equal(reportId);
+        expect(actualThing1.my_sibling_1).to.equal(doc2_id);
 
         const actualThing2 = actual[2];
-        chai.expect(actualThing2._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualThing2.some_property_2).to.equal('some_value_2');
-        chai.expect(actualThing2.my_self_2).to.equal(doc2_id);
-        chai.expect(actualThing2.my_parent_2).to.equal(reportId);
-        chai.expect(actualThing2.my_sibling_2).to.equal(doc1_id);
+        expect(actualThing2._id).to.match(/(\w+-)\w+/);
+        expect(actualThing2.some_property_2).to.equal('some_value_2');
+        expect(actualThing2.my_self_2).to.equal(doc2_id);
+        expect(actualThing2.my_parent_2).to.equal(reportId);
+        expect(actualThing2.my_sibling_2).to.equal(doc1_id);
 
-        chai.expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
+        expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(3);
       });
     });
 
@@ -839,34 +841,34 @@ describe('Enketo service', () => {
       dbGetAttachment.resolves('<form/>');
       UserContact.resolves({ _id: '123', phone: '555' });
       return service.save('V', form).then(function(actual) {
-        chai.expect(form.validate.callCount).to.equal(1);
-        chai.expect(form.getDataStr.callCount).to.equal(1);
-        chai.expect(dbBulkDocs.callCount).to.equal(1);
-        chai.expect(UserContact.callCount).to.equal(1);
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
 
-        chai.expect(actual.length).to.equal(4);
+        expect(actual.length).to.equal(4);
         const reportId = actual[0]._id;
 
         const actualReport = actual[0];
-        chai.expect(actualReport._id).to.match(/(\w+-)\w+/);
-        chai.expect(actualReport.fields.name).to.equal('Sally');
-        chai.expect(actualReport.fields.lmp).to.equal('10');
-        chai.expect(actualReport.fields.secret_code_name).to.equal('S4L');
-        chai.expect(actualReport.form).to.equal('V');
-        chai.expect(actualReport.type).to.equal('data_record');
-        chai.expect(actualReport.content_type).to.equal('xml');
-        chai.expect(actualReport.contact._id).to.equal('123');
-        chai.expect(actualReport.from).to.equal('555');
-        chai.expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
+        expect(actualReport._id).to.match(/(\w+-)\w+/);
+        expect(actualReport.fields.name).to.equal('Sally');
+        expect(actualReport.fields.lmp).to.equal('10');
+        expect(actualReport.fields.secret_code_name).to.equal('S4L');
+        expect(actualReport.form).to.equal('V');
+        expect(actualReport.type).to.equal('data_record');
+        expect(actualReport.content_type).to.equal('xml');
+        expect(actualReport.contact._id).to.equal('123');
+        expect(actualReport.from).to.equal('555');
+        expect(actualReport.hidden_fields).to.deep.equal([ 'secret_code_name' ]);
 
         for (let i=1; i<=3; ++i) {
           const repeatDocN = actual[i];
-          chai.expect(repeatDocN._id).to.match(/(\w+-)\w+/);
-          chai.expect(repeatDocN.my_parent).to.equal(reportId);
-          chai.expect(repeatDocN.some_property).to.equal('some_value_'+i);
+          expect(repeatDocN._id).to.match(/(\w+-)\w+/);
+          expect(repeatDocN.my_parent).to.equal(reportId);
+          expect(repeatDocN.some_property).to.equal('some_value_'+i);
         }
 
-        chai.expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(4);
+        expect(_.uniq(_.pluck(actual, '_id')).length).to.equal(4);
       });
     });
 
@@ -893,12 +895,12 @@ describe('Enketo service', () => {
       UserContact.resolves({ _id: 'my-user', phone: '8989' });
       dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
       return service.save('my-form', form, true).then(() => {
-        chai.expect(AddAttachment.callCount).to.equal(2);
-        chai.expect(AddAttachment.args[0][1]).to.equal('content');
+        expect(AddAttachment.callCount).to.equal(2);
+        expect(AddAttachment.args[0][1]).to.equal('content');
 
-        chai.expect(AddAttachment.args[1][1]).to.equal('user-file/my-form/my_file');
-        chai.expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'image', foo: 'bar' });
-        chai.expect(AddAttachment.args[1][3]).to.equal('image');
+        expect(AddAttachment.args[1][1]).to.equal('user-file/my-form/my_file');
+        expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'image', foo: 'bar' });
+        expect(AddAttachment.args[1][3]).to.equal('image');
       });
     });
 
@@ -932,17 +934,17 @@ describe('Enketo service', () => {
       UserContact.resolves({ _id: 'my-user', phone: '8989' });
       dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
       return service.save('my-form-internal-id', form, true).then(() => {
-        chai.expect(AddAttachment.callCount).to.equal(3);
-        chai.expect(AddAttachment.args[0][1]).to.equal('content');
+        expect(AddAttachment.callCount).to.equal(3);
+        expect(AddAttachment.args[0][1]).to.equal('content');
 
-        chai.expect(AddAttachment.args[1][1]).to.equal('user-file/my-form-internal-id/my_file');
-        chai.expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'image', foo: 'bar' });
-        chai.expect(AddAttachment.args[1][3]).to.equal('image');
+        expect(AddAttachment.args[1][1]).to.equal('user-file/my-form-internal-id/my_file');
+        expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'image', foo: 'bar' });
+        expect(AddAttachment.args[1][3]).to.equal('image');
 
-        chai.expect(AddAttachment.args[2][1])
+        expect(AddAttachment.args[2][1])
           .to.equal('user-file/my-form-internal-id/sub_element/sub_sub_element/other_file');
-        chai.expect(AddAttachment.args[2][2]).to.deep.equal({ type: 'mytype', foo: 'baz' });
-        chai.expect(AddAttachment.args[2][3]).to.equal('mytype');
+        expect(AddAttachment.args[2][2]).to.deep.equal({ type: 'mytype', foo: 'baz' });
+        expect(AddAttachment.args[2][3]).to.equal('mytype');
       });
     });
   });


### PR DESCRIPTION
# Description

Because of replication depth, the `contact_id` for a task's action may not be present on the device. This change makes it so enketo does a "best effort" to inject contact data when none is present, instead of throwing when building a ContactSummary.

Reports associated with contacts which are not on the device are not grouped under the same contact even when the associated contact id is the same. This updates RulesEngine to group reports by contact id in such cases.

#5789 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
