### PR TITLE
Don't query docs_by_replication_key for offline _bulk_docs requests

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -241,9 +241,8 @@ const excludeTombstoneIds = (docIds) => {
   return docIds.filter(docId => !tombstoneUtils.isTombstoneId(docId));
 };
 
-const convertTombstoneIds = (docIds) => {
-  return docIds.map(docId => tombstoneUtils.isTombstoneId(docId) ? tombstoneUtils.extractStub(docId).id : docId);
-};
+const convertTombstoneId = docId => tombstoneUtils.isTombstoneId(docId) ? tombstoneUtils.extractStub(docId).id : docId;
+const convertTombstoneIds = docIds => docIds.map(convertTombstoneId);
 
 const getViewResults = (doc) => {
   return {
@@ -269,5 +268,7 @@ module.exports = {
   alwaysAllowCreate: alwaysAllowCreate,
   updateContext: updateContext,
   filterAllowedDocs: filterAllowedDocs,
-  isDeleteStub: tombstoneUtils._isDeleteStub
+  isDeleteStub: tombstoneUtils._isDeleteStub,
+  generateTombstoneId: tombstoneUtils.generateTombstoneId,
+  convertTombstoneId: convertTombstoneId
 };

--- a/api/src/services/bulk-docs.js
+++ b/api/src/services/bulk-docs.js
@@ -177,7 +177,7 @@ const filterNewDocs = (allowedDocIds, docs) => {
 
 // returns a list of filtered docs the user is allowed to update/create
 const filterAllowedDocs = (authorizationContext, docs) => {
-  const docObjs = docs.map(doc => ({
+  docs = docs.map(doc => ({
     doc,
     viewResults: authorization.getViewResults(doc),
     allowed: authorization.alwaysAllowCreate(doc),
@@ -186,7 +186,7 @@ const filterAllowedDocs = (authorizationContext, docs) => {
     },
   }));
   return authorization
-    .filterAllowedDocs(authorizationContext, docObjs)
+    .filterAllowedDocs(authorizationContext, docs)
     .map(docObj => docObj.doc);
 };
 

--- a/shared-libs/tombstone-utils/src/tombstone-utils.js
+++ b/shared-libs/tombstone-utils/src/tombstone-utils.js
@@ -128,7 +128,9 @@ module.exports = {
     }
 
     return change;
-  }
+  },
+
+  generateTombstoneId: generateTombstoneId,
 };
 
 // exposed for testing


### PR DESCRIPTION
# Description

Instead of loading all allowed doc ids in order to determine if a user can edit existent docs, use `_all_docs` requests to get current revs of uploaded docs and determine whether the user can edit them by running view map queries over them. 

Running locally, using the seed data (from gamma.dev): performance difference:

Instance | Uploading 100 docs to the server | Uploading 1 doc to the server 
-- | -- | --
master | 1112ms | 1088 ms |
this PR | 230ms | 87ms | 



medic/medic#5797

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
