### PR TITLE
Fix auto-conversion of data while parsing

### DIFF
--- a/api/src/services/report/smsparser.js
+++ b/api/src/services/report/smsparser.js
@@ -166,12 +166,12 @@ exports.parseField = (field, raw) => {
         for (let i of field.list) {
           const item = field.list[i];
           if (item[0] === raw) {
-            return config.translate(item[1]);
+            return item[1];
           }
         }
         logger.warn(`Option not available for ${raw} in list.`);
       }
-      return config.translate(raw);
+      return raw;
     case 'date':
       if (!raw) {
         return null;

--- a/api/tests/mocha/services/report/smsparser.spec.js
+++ b/api/tests/mocha/services/report/smsparser.spec.js
@@ -1333,5 +1333,38 @@ describe('sms parser', () => {
     const data = smsparser.parse(def, doc);
     chai.expect(data).to.deep.equal({name: 'jane'});
   });
-
+  
+  it('stop input value of yes/no from getting translated to Yes/No', () => {
+    const def = {
+      meta: {
+        code: 'c_imm'
+      },
+      fields: {
+        bcg: {
+          type: 'string',
+          labels: {
+            tiny: 'bcg'
+          }
+        },
+        ch: {
+          type: 'string',
+          labels: {
+            tiny: 'ch'
+          } 
+        }
+      }
+    };
+    sinon.stub(config, 'translate')
+      .withArgs('bcg').returns('bcg')
+      .withArgs('ch').returns('ch')
+      .withArgs('no').returns('no')
+      .withArgs('yes').returns('yes');
+    const doc = {
+      message: 'J1!c_imm!bcg#yes#ch#no'
+    };
+    const data = smsparser.parse(def, doc);
+    console.log(JSON.stringify(config.translate.args, null, 2));
+    chai.expect(data).to.deep.equal({bcg: 'yes', ch:'no'});
+    chai.expect(config.translate.callCount).to.equal(2);
+  });
 });

--- a/api/tests/mocha/services/report/smsparser.spec.js
+++ b/api/tests/mocha/services/report/smsparser.spec.js
@@ -1363,7 +1363,6 @@ describe('sms parser', () => {
       message: 'J1!c_imm!bcg#yes#ch#no'
     };
     const data = smsparser.parse(def, doc);
-    console.log(JSON.stringify(config.translate.args, null, 2));
     chai.expect(data).to.deep.equal({bcg: 'yes', ch:'no'});
     chai.expect(config.translate.callCount).to.equal(2);
   });


### PR DESCRIPTION
# Description
The data `yes/no` submitted through immunization form or SMS was being auto-converted to `Yes/No` in the corresponding json created in couchdb; this fix prevents the translation of the value as per `translation-xx.properties`. More details are in GH issue medic/medic#5762

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
