### PR TITLE
Adds custom now and today implementations to medic-xpath-extensions

### DIFF
--- a/webapp/src/js/enketo/OpenrosaXpathEvaluatorBinding.js
+++ b/webapp/src/js/enketo/OpenrosaXpathEvaluatorBinding.js
@@ -16,6 +16,7 @@ module.exports = function() {
     this.xml.jsEvaluate = function(e, contextPath, namespaceResolver, resultType, result) {
         var extensions = openrosaExtensions(translator.t);
         extensions.func = _.extend(extensions.func, medicExtensions.func);
+        extensions.process = _.extend(extensions.process, medicExtensions.process);
         var wrappedXpathEvaluator = function(v) {
             // Node requests (i.e. result types greater than 3 (BOOLEAN)
             // should be processed unaltered, as they are passed this

--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -14,11 +14,54 @@ var getValue = function(resultObject) {
   return resultObject.v;
 };
 
+var now_and_today = function() { return { t: 'date', v: new Date() }; };
+
+Date.prototype.toISOLocalString = function() {
+    //2012-09-05T12:57:00.000-04:00 (ODK)
+
+    if ( this.toString() === 'Invalid Date' ) {
+        return this.toString();
+    }
+
+    var dt = new Date( this.getTime() - ( this.getTimezoneOffset() * 60 * 1000 ) ).toISOString()
+        .replace( 'Z', this.getTimezoneOffsetAsTime() );
+
+    if ( dt.indexOf( 'T00:00:00.000' ) > 0 ) {
+        return dt.split( 'T' )[ 0 ];
+    } else {
+        return dt;
+    }
+};
+
+Date.prototype.getTimezoneOffsetAsTime = function() {
+    var offsetMinutesTotal;
+    var hours;
+    var minutes;
+    var direction;
+    var pad2 = function( x ) {
+        return ( x < 10 ) ? '0' + x : x;
+    };
+
+    if ( this.toString() === 'Invalid Date' ) {
+        return this.toString();
+    }
+
+    offsetMinutesTotal = this.getTimezoneOffset();
+
+    direction = ( offsetMinutesTotal < 0 ) ? '+' : '-';
+    hours = pad2( Math.abs( Math.floor( offsetMinutesTotal / 60 ) ) );
+    minutes = pad2( Math.abs( Math.floor( offsetMinutesTotal % 60 ) ) );
+
+    return direction + hours + ':' + minutes;
+};
+
 module.exports = {
   init: function(_zscoreUtil) {
     zscoreUtil = _zscoreUtil;
   },
   func: {
+    now: now_and_today,
+    today: now_and_today,
     'z-score': function() {
       var args = Array.from(arguments).map(function(arg) {
         return getValue(arg);
@@ -29,5 +72,16 @@ module.exports = {
       }
       return { t: 'num', v: result };
     }
+  },
+  process: {
+    toExternalResult: function(r) {
+      if(r.t === 'date') {
+        return {
+          resultType:XPathResult.STRING_TYPE,
+          numberValue:r.v.getTime(),
+          stringValue:r.v.toISOLocalString(),
+        };
+      }
+    }  
   }
 };

--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -16,46 +16,39 @@ var getValue = function(resultObject) {
 
 var now_and_today = function() { return { t: 'date', v: new Date() }; };
 
-Date.prototype.toISOLocalString = function() {
-    //2012-09-05T12:57:00.000-04:00 (ODK)
+var toISOLocalString = function(date) {
+  if (date.toString() === 'Invalid Date') {
+    return date.toString();
+  }
 
-    if ( this.toString() === 'Invalid Date' ) {
-        return this.toString();
-    }
+  var dt = new Date(date.getTime() - (date.getTimezoneOffset() * 60 * 1000))
+            .toISOString()
+            .replace('Z', module.exports.getTimezoneOffsetAsTime(date));
 
-    var dt = new Date( this.getTime() - ( this.getTimezoneOffset() * 60 * 1000 ) ).toISOString()
-        .replace( 'Z', this.getTimezoneOffsetAsTime() );
-
-    if ( dt.indexOf( 'T00:00:00.000' ) > 0 ) {
-        return dt.split( 'T' )[ 0 ];
-    } else {
-        return dt;
-    }
+  return dt;
 };
 
-Date.prototype.getTimezoneOffsetAsTime = function() {
-    var offsetMinutesTotal;
-    var hours;
-    var minutes;
-    var direction;
-    var pad2 = function( x ) {
-        return ( x < 10 ) ? '0' + x : x;
-    };
+var getTimezoneOffsetAsTime = function(date) {
+  var pad2 = function(x) {
+    return ( x < 10 ) ? '0' + x : x;
+  };
 
-    if ( this.toString() === 'Invalid Date' ) {
-        return this.toString();
-    }
+  if (date.toString() === 'Invalid Date') {
+    return date.toString();
+  }
 
-    offsetMinutesTotal = this.getTimezoneOffset();
+  const offsetMinutesTotal = date.getTimezoneOffset();
 
-    direction = ( offsetMinutesTotal < 0 ) ? '+' : '-';
-    hours = pad2( Math.abs( Math.floor( offsetMinutesTotal / 60 ) ) );
-    minutes = pad2( Math.abs( Math.floor( offsetMinutesTotal % 60 ) ) );
+  const direction = (offsetMinutesTotal < 0) ? '+' : '-';
+  const hours = pad2(Math.abs(Math.floor(offsetMinutesTotal / 60)));
+  const minutes = pad2(Math.abs(Math.floor(offsetMinutesTotal % 60)));
 
-    return direction + hours + ':' + minutes;
+  return direction + hours + ':' + minutes;
 };
 
 module.exports = {
+  getTimezoneOffsetAsTime: getTimezoneOffsetAsTime,
+  toISOLocalString: toISOLocalString,
   init: function(_zscoreUtil) {
     zscoreUtil = _zscoreUtil;
   },
@@ -77,9 +70,9 @@ module.exports = {
     toExternalResult: function(r) {
       if(r.t === 'date') {
         return {
-          resultType:XPathResult.STRING_TYPE,
-          numberValue:r.v.getTime(),
-          stringValue:r.v.toISOLocalString(),
+          resultType: XPathResult.STRING_TYPE,
+          numberValue: r.v.getTime(),
+          stringValue: module.exports.toISOLocalString(r.v),
         };
       }
     }  

--- a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
+++ b/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
@@ -1,0 +1,52 @@
+const assert = require('chai').assert;
+const medicXpathExtensions = require('../../../../src/js/enketo/medic-xpath-extensions');
+
+const func = medicXpathExtensions.func;
+
+const getTimezoneOffset = Date.prototype.getTimezoneOffset;
+
+describe('medic-xpath-extensions', function() {
+  afterEach(done => {
+    Date.prototype.getTimezoneOffset = getTimezoneOffset;
+    done();
+  });
+
+  describe('now() and today()', function() {
+    it('should have the same implementation', function() {
+      assert.equal(func.today, func.now);
+      assert.equal(func.now, func.today);
+    });
+  });
+
+  describe('now()', function() {
+    it('returns a result of type `date`', function() {
+      assert.equal(func.now().t, 'date');
+    });
+
+    it('returns a value which is instance of Date', function() {
+      assert.ok(func.now().v instanceof Date);
+    });
+  });
+
+  describe('getTimezoneOffsetAsTime()', function() {
+    it('returns the time zone offset in hours when given a time zone difference in minutes', function() {
+      Date.prototype.getTimezoneOffset = () => -60;
+      assert.equal(medicXpathExtensions.getTimezoneOffsetAsTime(new Date()), '+01:00');
+    });
+
+    it('returns a negative time zone offset when given a positive time zone difference', function() {
+      Date.prototype.getTimezoneOffset = () => 60;
+      assert.equal(medicXpathExtensions.getTimezoneOffsetAsTime(new Date()), '-01:00');
+    });
+  });
+
+  describe('toISOLocalString()', function() {
+    it('returns the ISO local string consistent with the time zone offset', function() {
+      const date = new Date('August 19, 1975 23:15:30 GMT+07:00');
+      Date.prototype.getTimezoneOffset = () => -60;
+      assert.equal(medicXpathExtensions.toISOLocalString(date), '1975-08-19T17:15:30.000+01:00');
+      Date.prototype.getTimezoneOffset = () => 60;
+      assert.equal(medicXpathExtensions.toISOLocalString(date), '1975-08-19T15:15:30.000-01:00');
+    });
+  });
+});


### PR DESCRIPTION
# Description

Adds custom now and today implementations to medic-xpath-extensions

medic/medic#5768

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
