### PR TITLE
Recurse when generating list of hidden fields

### DIFF
--- a/webapp/src/js/services/enketo-translation.js
+++ b/webapp/src/js/services/enketo-translation.js
@@ -15,6 +15,19 @@ angular.module('inboxServices').service('EnketoTranslation',
           .find(node => node.nodeName === childNodeName);
     };
 
+    const getHiddenFieldList = (nodes, prefix, current) => {
+      nodes.forEach(node => {
+        const path = prefix + node.nodeName;
+        const attr = node.attributes.getNamedItem('tag');
+        if (attr && attr.value === 'hidden') {
+          current.push(path);
+        } else {
+          const children = withElements(node.childNodes);
+          getHiddenFieldList(children, path + '.', current);
+        }
+      });
+    };
+
     var nodesToJs = function(data, repeatPaths, path) {
       repeatPaths = repeatPaths || [];
       path = path || '';
@@ -104,12 +117,13 @@ angular.module('inboxServices').service('EnketoTranslation',
     return {
       getHiddenFieldList: function(model) {
         model = $.parseXML(model).firstChild;
-        return model && withElements(model.childNodes)
-          .filter(function(n) {
-            var attr = n.attributes.getNamedItem('tag');
-            return attr && attr.value === 'hidden';
-          })
-          .map(n => n.nodeName);
+        if (!model) {
+          return;
+        }
+        const children = withElements(model.childNodes);
+        const fields = [];
+        getHiddenFieldList(children, '', fields);
+        return fields;
       },
 
       reportRecordToJs: function(record, formXml) {

--- a/webapp/tests/karma/unit/services/enketo-translation.js
+++ b/webapp/tests/karma/unit/services/enketo-translation.js
@@ -391,6 +391,44 @@ describe('EnketoTranslation service', () => {
       // then
       assert.deepEqual(hidden_fields, [ 'secret_code_name_one', 'secret_code_name_two' ]);
     });
+
+    it('hides sections tagged `hidden`', () => {
+      // given
+      const xml =
+        `<doc>
+          <name>Sally</name>
+          <secret tag="hidden">
+            <first>a</first>
+            <second>b</second>
+          </secret>
+          <lmp>10</lmp>
+        </doc>`;
+
+      // when
+      const hidden_fields = service.getHiddenFieldList(xml);
+
+      // then
+      assert.deepEqual(hidden_fields, [ 'secret' ]);
+    });
+
+    it('recurses to find `hidden` children', () => {
+      // given
+      const xml =
+        `<doc>
+          <name>Sally</name>
+          <secret>
+            <first tag="hidden">a</first>
+            <second>b</second>
+          </secret>
+          <lmp tag="hidden">10</lmp>
+        </doc>`;
+
+      // when
+      const hidden_fields = service.getHiddenFieldList(xml);
+
+      // then
+      assert.deepEqual(hidden_fields, [ 'secret.first', 'lmp' ]);
+    });
   });
 
   describe('#bindJsonToXml()', () => {


### PR DESCRIPTION
medic/medic#5747

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
