### PR TITLE
Remove translation of fields values

### DIFF
--- a/api/src/services/report/smsparser.js
+++ b/api/src/services/report/smsparser.js
@@ -143,19 +143,16 @@ exports.parseField = (field, raw) => {
       if (raw === '') {
         return null;
       }
-      // store list value since it has more meaning.
-      // TODO we don't have locale data inside this function so calling
-      // translate does not resolve locale.
       if (field.list) {
         for (let i of field.list) {
           const item = field.list[i];
           if (item[0] === raw) {
-            return config.translate(item[1]);
+            return item[1];
           }
         }
         logger.warn(`Option not available for ${raw} in list.`);
       }
-      return config.translate(raw);
+      return raw;
     case 'date':
       if (!raw) {
         return null;

--- a/api/tests/mocha/services/report/smsparser.spec.js
+++ b/api/tests/mocha/services/report/smsparser.spec.js
@@ -1334,4 +1334,37 @@ describe('sms parser', () => {
     chai.expect(data).to.deep.equal({name: 'jane'});
   });
 
+  it('stop input valuesfrom getting translated', () => {
+    const def = {
+      meta: {
+        code: 'c_imm'
+      },
+      fields: {
+        bcg: {
+          type: 'string',
+          labels: {
+            tiny: 'bcg'
+          }
+        },
+        ch: {
+          type: 'string',
+          labels: {
+            tiny: 'ch'
+          } 
+        }
+      }
+    };
+    sinon.stub(config, 'translate')
+      .withArgs('bcg').returns('bcg')
+      .withArgs('ch').returns('ch')
+      .withArgs('no').returns('no')
+      .withArgs('yes').returns('yes');
+    const doc = {
+      message: 'J1!c_imm!bcg#yes#ch#no'
+    };
+    const data = smsparser.parse(def, doc);
+    chai.expect(data).to.deep.equal({bcg: 'yes', ch:'no'});
+    chai.expect(config.translate.callCount).to.equal(2);
+  });
+
 });


### PR DESCRIPTION
The data submitted through immunization forms was being translated
in the saved doc. This fix removes the translation of the values.

medic/medic#5762

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
