### PR TITLE
Delay secondary startup tasks

### DIFF
--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -222,11 +222,11 @@ var _ = require('underscore'),
         Telemetry.record('boot_time', dbWarmed - $window.startupTimes.start);
 
         delete $window.startupTimes;
-        initSecondaryServices();
+        lazyLoadTasks();
       });
 
     // initialisation tasks that can occur after the UI has been rendered
-    const initSecondaryServices = () => {
+    const lazyLoadTasks = () => {
       Session.init()
         .then(() => initForms())
         .then(() => initTours())

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -220,7 +220,7 @@ var _ = require('underscore'),
       });
 
     // initialisation tasks that can occur after the UI has been remdered
-    const initSecondaryServices = () {
+    const initSecondaryServices = () => {
       // TODO order this and serialize?
       Session.init();
       CheckDate();

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -229,8 +229,8 @@ var _ = require('underscore'),
     const initSecondaryServices = () => {
       Session.init()
         .then(() => initForms())
-        .then(() => initUnreadCount())
         .then(() => initTours())
+        .then(() => initUnreadCount())
         .then(() => CheckDate());
     };
 

--- a/webapp/src/js/services/session.js
+++ b/webapp/src/js/services/session.js
@@ -34,7 +34,7 @@ var COOKIE_NAME = 'userCtx',
       };
 
       var logout = function() {
-        $http.delete('/_session')
+        return $http.delete('/_session')
           .catch(function() {
             // Set cookie to force login before using app
             ipCookie('login', 'force', { path: '/' });
@@ -42,25 +42,20 @@ var COOKIE_NAME = 'userCtx',
           .then(navigateToLogin);
       };
 
-      var refreshUserCtx = function(callback) {
-        $http
+      var refreshUserCtx = function() {
+        return $http
           .get('/' + Location.dbName + '/login/identity')
-          .then(function() {
-            if (_.isFunction(callback)) {
-              callback();
-            }
-          })
           .catch(function() {
-            logout();
+            return logout();
           });
       };
 
-      var checkCurrentSession = function(callback) {
+      var checkCurrentSession = function() {
         var userCtx = getUserCtx();
         if (!userCtx || !userCtx.name) {
           return logout();
         }
-        $http.get('/_session')
+        return $http.get('/_session')
           .then(function(response) {
             var name = response.data &&
                        response.data.userCtx &&
@@ -71,7 +66,7 @@ var COOKIE_NAME = 'userCtx',
             }
             if (_.difference(userCtx.roles, response.data.userCtx.roles).length ||
                 _.difference(response.data.userCtx.roles, userCtx.roles).length) {
-              return refreshUserCtx(callback);
+              return refreshUserCtx();
             }
           })
           .catch(function(response) {

--- a/webapp/tests/karma/unit/controllers/inbox.js
+++ b/webapp/tests/karma/unit/controllers/inbox.js
@@ -28,7 +28,7 @@ describe('InboxCtrl controller', () => {
     };
 
     session = {
-      init: sinon.stub(),
+      init: sinon.stub().resolves(),
       isAdmin: sinon.stub(),
       userCtx: sinon.stub(),
       isOnlineOnly: sinon.stub()
@@ -218,6 +218,6 @@ describe('InboxCtrl controller', () => {
 
   it('InboxUserContent Changes listener callback should check current session', () => {
     changesListener['inbox-user-context'].callback();
-    chai.expect(session.init.callCount).to.equal(2);
+    chai.expect(session.init.callCount).to.equal(1);
   });
 });

--- a/webapp/tests/karma/unit/services/session.js
+++ b/webapp/tests/karma/unit/services/session.js
@@ -127,40 +127,6 @@ describe('Session service', function() {
     done();
   });
 
-  it('refreshes user context cookie if a role change is detected', () => {
-    ipCookie.returns({ name: 'adm', roles: ['alpha', 'omega'] });
-    Location.dbName = 'DB_NAME';
-    $httpBackend.when('GET', '/DB_NAME/login/identity').respond(200);
-    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
-    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
-    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
-    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['alpha', 'omega', 'beta'] } });
-    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['alpha'] } });
-    const callback = sinon.stub();
-
-    service.init(callback);
-    service.init();
-    service.init('something');
-    service.init(callback);
-    service.init(callback);
-
-    $httpBackend.flush();
-    chai.expect(callback.callCount).to.equal(3);
-  });
-
-  it('does not refresh user context if a role change is not detected', () => {
-    ipCookie.returns({ name: 'adm', roles: ['beta'] });
-    Location.dbName = 'DB_NAME';
-    $httpBackend.expect('GET', '/_session').respond(200, { userCtx: { name: 'adm', roles: ['beta'] } });
-    const callback = sinon.stub();
-
-    service.init(callback);
-    $httpBackend.flush(1);
-
-    chai.expect(callback.callCount).to.equal(0);
-    $httpBackend.verifyNoOutstandingExpectation();
-  });
-
   describe('isAdmin function', function() {
 
     it('returns false if not logged in', function(done) {


### PR DESCRIPTION
# Description

Attempting to initialise everything all at once is inflating our
time to first paint. By delaying less important things until the
db is warmed and the UI is rendered the user can begin interacting
with the app sooner.

#5859

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
