### PR TITLE
Task list in places view doesn't include the tasks of children

### DIFF
--- a/webapp/src/js/services/tasks-for-contact.js
+++ b/webapp/src/js/services/tasks-for-contact.js
@@ -75,7 +75,7 @@ angular.module('inboxServices').factory('TasksForContact',
       if (!model.type.person && model.children) {
         model.children.forEach(child => {
           if (child.type.person && child.contacts && child.contacts.length) {
-            contactIds.push(...child.contacts.map(contact => contact._id));
+            contactIds.push(...child.contacts.map(contact => contact.id));
           }
         });
       }

--- a/webapp/tests/karma/unit/services/tasks-for-contact.js
+++ b/webapp/tests/karma/unit/services/tasks-for-contact.js
@@ -150,7 +150,7 @@ describe('TasksForContact service', function() {
 
     const model = {
       doc: { _id: docId },
-      children: [ { type: PERSON_TYPE, contacts: [{ _id: 'child1' }, { _id: 'child2' }] } ],
+      children: [ { type: PERSON_TYPE, contacts: [{ id: 'child1' }, { id: 'child2' }] } ],
       type: CLINIC_TYPE
     };
     stubRulesEngine(null, tasks);
@@ -181,7 +181,7 @@ describe('TasksForContact service', function() {
     ];
     const model = {
       doc: { _id: docId },
-      children: [{ type: PERSON_TYPE, contacts: [{ _id: childPersonId }] }],
+      children: [{ type: PERSON_TYPE, contacts: [{ id: childPersonId }] }],
       type: PERSON_TYPE
     };
     stubRulesEngine(null, tasks);
@@ -202,7 +202,7 @@ describe('TasksForContact service', function() {
     ];
     const model = {
       doc: { _id: docId },
-      children: [{ type: PERSON_TYPE, contacts: [{ _id: childPersonId }] }],
+      children: [{ type: PERSON_TYPE, contacts: [{ id: childPersonId }] }],
       type: CLINIC_TYPE
     };
     stubRulesEngine(null, tasks);
@@ -344,7 +344,7 @@ describe('TasksForContact service', function() {
 
     const model = {
       doc: { _id: docId },
-      children: [{ type: PERSON_TYPE, contacts: [{ _id: childPersonId }] }],
+      children: [{ type: PERSON_TYPE, contacts: [{ id: childPersonId }] }],
       type: CLINIC_TYPE
     };
     stubRulesEngine(null, tasks);


### PR DESCRIPTION
# Description

`model.children.contacts` is the result of a query, so it has an `id` or a `.doc._id`
#5899

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
