### PR TITLE
5768 incorrect xlsform metadata

### DIFF
--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -525,13 +525,14 @@ angular.module('inboxServices').service('Enketo',
     };
 
     this.save = function(formInternalId, form, geolocation, docId) {
-      form.view.$.trigger('beforesave');
-
       return $q.resolve(form.validate())
         .then(function(valid) {
           if (!valid) {
             throw new Error('Form is invalid');
           }
+
+          $('form.or').trigger('beforesave');
+
           if (docId) {
             return update(docId);
           }

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -525,6 +525,8 @@ angular.module('inboxServices').service('Enketo',
     };
 
     this.save = function(formInternalId, form, geolocation, docId) {
+      form.view.$.trigger('beforesave');
+
       return $q.resolve(form.validate())
         .then(function(valid) {
           if (!valid) {

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -83,6 +83,11 @@ describe('Enketo service', () => {
       form = {
         validate: sinon.stub(),
         getDataStr: sinon.stub(),
+        view: {
+          '$': {
+            trigger: sinon.stub()
+          }
+        }
       },
       AddAttachment = sinon.stub(),
       EnketoForm = sinon.stub(),

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -82,12 +82,7 @@ describe('Enketo service', () => {
       TranslateFrom = sinon.stub(),
       form = {
         validate: sinon.stub(),
-        getDataStr: sinon.stub(),
-        view: {
-          '$': {
-            trigger: sinon.stub()
-          }
-        }
+        getDataStr: sinon.stub()
       },
       AddAttachment = sinon.stub(),
       EnketoForm = sinon.stub(),


### PR DESCRIPTION
# Description

Triggering before save to update possible 'end' timestamp in form:
https://github.com/enketo/enketo-core/blob/a59c3322311b8966afc0f926392f7b1e193ebbce/src/js/preload.js#L50-L58

medic/medic#5768

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
