### PR TITLE
Updates admin modal error and warning styles

### DIFF
--- a/admin/src/js/controllers/edit-user.js
+++ b/admin/src/js/controllers/edit-user.js
@@ -304,7 +304,8 @@ angular
           if (resp.data.warn) {
             return $q.reject({
               key: 'configuration.user.replication.limit.exceeded',
-              params: { total_docs: resp.data.total_docs, limit: resp.data.limit }
+              params: { total_docs: resp.data.total_docs, limit: resp.data.limit },
+              severity: 'warning'
             });
           }
 
@@ -398,7 +399,7 @@ angular
           })
           .catch(function(err) {
             if (err.key) {
-              $translate(err.key, err.params).then(value => $scope.setError(err, value));
+              $translate(err.key, err.params).then(value => $scope.setError(err, value, err.severity));
             } else {
               $scope.setError(err, 'Error validating user');
             }

--- a/admin/src/templates/modal.html
+++ b/admin/src/templates/modal.html
@@ -5,7 +5,7 @@
   </div>
   <div class="modal-body" ng-transclude></div>
   <div class="modal-footer">
-    <p class="note" ng-if="status.error" translate>{{status.error}}</p>
+    <p class="alert" ng-class="status.severity === 'warning' ? 'alert-warning' : 'alert-danger'" ng-if="status.error" translate>{{status.error}}</p>
     <a class="btn cancel" ng-class="{ 'disabled': status.processing }" ng-click="onCancel()" translate>{{cancelKey || 'Cancel'}}</a>
     <a class="btn btn-danger pull-left" ng-show="showDelete" ng-click="onDelete()"><i class="fa fa-trash-o"></i>&nbsp;<span translate>{{deleteKey || 'Delete'}}</span></a>
     <a class="btn submit" ng-class="{ 'btn-primary': !danger, 'btn-danger': danger, 'disabled': disableSubmit }" mm-enter="onSubmit()" ng-click="onSubmit()" ng-show="!status.processing" translate>{{submitKey}}</a>

--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1231,4 +1231,4 @@ years = years
 yes = Yes
 yesterday = yesterday
 error.file.size = File must be no larger than {{size}}
-configuration.user.replication.limit.exceeded = This user would replicate {{total_docs}} docs, which exceeds the recommended limit. Do you wish to proceed?
+configuration.user.replication.limit.exceeded = Warning! This user would replicate {{total_docs}} docs, which exceeds the recommended limit. Edit the Role or Place to make changes as needed, then press Submit to proceed. If there are too many docs for a user consider adjusting the doc purge rules.

--- a/webapp/src/js/services/modal.js
+++ b/webapp/src/js/services/modal.js
@@ -42,15 +42,18 @@ angular.module('inboxServices').factory('Modal',
       scope.setProcessing = function() {
         scope.status.processing = true;
         scope.status.error = false;
+        scope.status.severity = false;
       };
       scope.setFinished = function() {
         scope.status.processing = false;
         scope.status.error = false;
+        scope.status.severity = false;
       };
-      scope.setError = function(err, message) {
+      scope.setError = function(err, message, severity) {
         $log.error('Error submitting modal', err);
         scope.status.processing = false;
         scope.status.error = message;
+        scope.status.severity = severity;
       };
       return scope;
     };


### PR DESCRIPTION
# Description

Updates styles so all modal error have `alert-danger` style.
Adds optional error severity to enable warning styles. 
Updates too-many-docs configuration warning message.

medic/medic#5362

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
