### PR TITLE
Updates `users-info` endpoint to accept multiple roles

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -999,7 +999,7 @@ When the requester has an online role, the following query parameters are accept
 | Variable | Description                                | Required | 
 | -------- | ------------------------------------------ | -------- |
 | facility_id | String identifier representing the uuid of the user's facility  | true |
-| role | String identifier representing the user role - must be configured as an offline role | true |
+| role | String identifier representing the user role - must be configured as an offline role. Accepts valid UTF8 JSON array for multiple of roles. | true |
 | contact_id | String identifier representing the uuid of the user's associated contact | false | 
  
 ##### Example

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -56,12 +56,17 @@ const getInfoUserCtx = req => {
     throw { code: 400, reason: 'Missing required query params: role and/or facility_id' };
   }
 
-  if (!auth.isOffline([ params.role ])) {
+  try {
+    params.role = JSON.parse(params.role);
+  } catch (err) { /* eslint-disable-line */ };
+  params.role = Array.isArray(params.role) ? params.role : [params.role];
+
+  if (!auth.isOffline(params.role)) {
     throw { code: 400, reason: 'Provided role is not offline' };
   }
 
   return {
-    roles: [ params.role ],
+    roles: params.role,
     facility_id: params.facility_id,
     contact_id: params.contact_id
   };

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -254,7 +254,7 @@ describe('Users API', () => {
           _id: 'fixture:user:offline',
           name: 'OfflineUser'
         },
-        roles: ['district_admin']
+        roles: ['district_admin', 'this', 'user', 'will', 'be', 'offline']
       },
       {
         username: 'online',
@@ -334,6 +334,17 @@ describe('Users API', () => {
       });
     });
 
+    it('should return correct number of allowed docs when requested by online user for an array of roles', () => {
+      const params = {
+        role: JSON.stringify(['random', 'district_admin', 'random']),
+        facility_id: 'fixture:offline'
+      };
+      onlineRequestOptions.path += '?' + querystring.stringify(params);
+      return utils.request(onlineRequestOptions).then(resp => {
+        expect(resp).toEqual({ total_docs: expectedNbrDocs, warn: false, limit: 10000 });
+      });
+    });
+
     it('should ignore parameters for requests from offline users', () => {
       const params = {
         role: 'district_admin',
@@ -350,7 +361,7 @@ describe('Users API', () => {
         role: 'national_admin',
         facility_id: 'fixture:offline'
       };
-      offlineRequestOptions.path += '?' + querystring.stringify(params);
+      onlineRequestOptions.path += '?' + querystring.stringify(params);
       onlineRequestOptions.headers = { 'Content-Type': 'application/json' };
       return utils
         .request(onlineRequestOptions)


### PR DESCRIPTION
# Description

Updates `users-info` endpoint to accept multiple roles as a JSON stringified string to support how roles are used in production.

medic/medic#5362

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
