### PR TITLE
Show useful error when no relevant fields

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -592,6 +592,10 @@ module.exports = function(grunt) {
             // patch enketo to always mark the /inputs group as relevant
             'patch webapp/node_modules/enketo-core/src/js/Form.js < webapp/patches/enketo-inputs-always-relevant.patch',
 
+            // patch enketo so forms with no active pages are considered valid
+            // https://github.com/medic/medic/issues/5484
+            'patch webapp/node_modules/enketo-core/src/js/page.js < webapp/patches/enketo-handle-no-active-pages.patch',
+
             // patch messageformat to add a default plural function for languages not yet supported by make-plural #5705
             'patch webapp/node_modules/messageformat/lib/plurals.js < webapp/patches/messageformat-default-plurals.patch',
           ];

--- a/webapp/patches/enketo-handle-no-active-pages.patch
+++ b/webapp/patches/enketo-handle-no-active-pages.patch
@@ -1,0 +1,22 @@
+*** webapp/node_modules/enketo-core/src/js/page.js	2019-09-10 13:09:07.407455858 +1200
+--- webapp/node_modules/enketo-core/src/js/page.new.js	2019-09-10 13:09:35.278897963 +1200
+***************
+*** 274,280 ****
+              .eq( 0 )
+              .trigger( 'fakefocus' );
+  
+!         pageEl.scrollIntoView();
+      },
+      toggleButtons: function( index ) {
+          var i = index || this.getCurrentIndex(),
+--- 274,283 ----
+              .eq( 0 )
+              .trigger( 'fakefocus' );
+  
+!         if (pageEl) {
+!             pageEl.scrollIntoView();
+!             console.warn('No active pages found. Make sure your form has at least one relevant input.');
+!         }
+      },
+      toggleButtons: function( index ) {
+          var i = index || this.getCurrentIndex(),


### PR DESCRIPTION
# Description

Patches enketo so it logs a useful warning rather than throwing
a cryptic Error.

medic/medic#5484

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
