### PR TITLE
Run e2e's CouchDB fresh each time via Docker

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,7 +139,7 @@ module.exports = function(grunt) {
           pass: couchConfig.password,
         },
         files: {
-          [couchConfig.withPathNoAuth('medic-test')]: 'build/ddocs/medic.json',
+          ['http://admin:pass@localhost:4984/medic-test']: 'build/ddocs/medic.json',
         },
       },
       staging: {
@@ -491,13 +491,24 @@ module.exports = function(grunt) {
           ` && curl -X PUT --data '"4294967296"' ${couchConfig.withPath('_node/' + COUCH_NODE_NAME + '/_config/httpd/max_http_request_size')}` +
           ` && curl -X PUT ${couchConfig.withPath(couchConfig.dbName)}`
       },
-      'reset-test-databases': {
-        stderr: false,
-        cmd: ['medic-test', 'medic-test-audit', 'medic-test-user-admin-meta', 'medic-test-sentinel', 'medic-test-users-meta']
-          .map(
-            name => `curl -X DELETE ${couchConfig.withPath(name)}`
-          )
-          .join(' && '),
+      'setup-test-database': {
+        // TODO: normalise this into a Medic Dockerfile
+        cmd: [
+          // 'docker run -d -p 4984:5984 -p 4986:5986 --name e2e-couchdb -v /home/scdf/dockers/e2e-couchdb/opt/couchdb/data:/opt/couchdb/data apache/couchdb:latest',
+          'docker run -d -p 4984:5984 -p 4986:5986 --name e2e-couchdb apache/couchdb:latest',
+          'sleep 1',
+          `curl 'http://localhost:4984/_cluster_setup' -H 'Content-Type: application/json' --data-binary '{"action":"enable_single_node","username":"admin","password":"pass","bind_address":"0.0.0.0","port":5984,"singlenode":true}'`,
+          'COUCH_URL=http://admin:pass@localhost:4984/medic grunt secure-couchdb', // yo dawg, I heard you like grunt...
+          // Useful for debugging etc, as it allows you to use Fauxton
+          `curl -X PUT "http://admin:pass@localhost:4984/_node/nonode@nohost/_config/httpd/WWW-Authenticate" -d '"Basic realm=\\"administrator\\""' -H "Content-Type: application/json"'`
+        ].join('; ')
+      },
+      'clean-test-database': {
+        cmd: [
+          'docker stop e2e-couchdb',
+          'docker rm e2e-couchdb',
+        ].join('; '),
+        exitCodes: [0, 1] // 1 if e2e-couchdb doesn't exist, which is fine
       },
       'e2e-servers': {
         cmd: 'node ./scripts/e2e-servers.js &'
@@ -1026,7 +1037,8 @@ module.exports = function(grunt) {
   // Test tasks
   grunt.registerTask('e2e-deploy', 'Deploy app for testing', [
     'start-webdriver',
-    'exec:reset-test-databases',
+    'exec:clean-test-database',
+    'exec:setup-test-database',
     'couch-push:test',
     'exec:e2e-servers',
   ]);
@@ -1034,15 +1046,18 @@ module.exports = function(grunt) {
   grunt.registerTask('e2e', 'Deploy app for testing and run e2e tests', [
     'e2e-deploy',
     'protractor:e2e-tests',
+    'exec:clean-test-database',
   ]);
 
   grunt.registerTask('e2e-debug', 'Deploy app for testing and run e2e tests in a visible Chrome window', [
     'e2e-deploy',
     'protractor:e2e-tests-debug',
+    'exec:clean-test-database',
   ]);
 
   grunt.registerTask('test-perf', 'Run performance-specific tests', [
-    'exec:reset-test-databases',
+    'exec:clean-test-database',
+    'exec:setup-test-database',
     'build-node-modules',
     'build-ddoc',
     'couch-compile:primary',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 const url = require('url');
 const packageJson = require('./package.json');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const {
@@ -492,21 +493,19 @@ module.exports = function(grunt) {
           ` && curl -X PUT ${couchConfig.withPath(couchConfig.dbName)}`
       },
       'setup-test-database': {
-        // TODO: normalise this into a Medic Dockerfile
         cmd: [
-          // 'docker run -d -p 4984:5984 -p 4986:5986 --name e2e-couchdb -v /home/scdf/dockers/e2e-couchdb/opt/couchdb/data:/opt/couchdb/data apache/couchdb:latest',
-          'docker run -d -p 4984:5984 -p 4986:5986 --name e2e-couchdb apache/couchdb:latest',
+          `docker run -d -p 4984:5984 -p 4986:5986 --name e2e-couchdb --mount type=tmpfs,destination=/opt/couchdb/data apache/couchdb:latest`,
           'sleep 1',
           `curl 'http://localhost:4984/_cluster_setup' -H 'Content-Type: application/json' --data-binary '{"action":"enable_single_node","username":"admin","password":"pass","bind_address":"0.0.0.0","port":5984,"singlenode":true}'`,
           'COUCH_URL=http://admin:pass@localhost:4984/medic grunt secure-couchdb', // yo dawg, I heard you like grunt...
-          // Useful for debugging etc, as it allows you to use Fauxton
+          // Useful for debugging etc, as it allows you to use Fauxton easily
           `curl -X PUT "http://admin:pass@localhost:4984/_node/nonode@nohost/_config/httpd/WWW-Authenticate" -d '"Basic realm=\\"administrator\\""' -H "Content-Type: application/json"'`
         ].join('; ')
       },
       'clean-test-database': {
         cmd: [
           'docker stop e2e-couchdb',
-          'docker rm e2e-couchdb',
+          'docker rm -v e2e-couchdb',
         ].join('; '),
         exitCodes: [0, 1] // 1 if e2e-couchdb doesn't exist, which is fine
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,6 @@
 const url = require('url');
 const packageJson = require('./package.json');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 
 const {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Core Framework of the Community Health Toolkit (CHT)
 
-These instructions are designed to help you run or develop on the Core Framework, a technical resource of the [Community Health Toolkit (CHT)](https://communityhealthtoolkit.org) contributed by Medic Mobile. 
+These instructions are designed to help you run or develop on the Core Framework, a technical resource of the [Community Health Toolkit (CHT)](https://communityhealthtoolkit.org) contributed by Medic Mobile.
 
 Medic Mobile is a nonprofit organization on a mission to improve health in the hardest-to-reach communities through open-source software. Medic Mobile serves as the technical steward of the Community Health Toolkit.
 
@@ -19,11 +19,11 @@ For the latest changes and release announcements see our [release notes](https:/
 
 ## Overview
 
-The CHT's Core Framework is a software architecture that makes it faster to build full-featured, scalable digital health apps that equip health workers to provide better care in their communities. To learn more about building an application with the Core Framework, visit our guide for [developing community health apps](https://github.com/medic/medic-docs/blob/master/configuration/developing-community-health-applications.md). 
+The CHT's Core Framework is a software architecture that makes it faster to build full-featured, scalable digital health apps that equip health workers to provide better care in their communities. To learn more about building an application with the Core Framework, visit our guide for [developing community health apps](https://github.com/medic/medic-docs/blob/master/configuration/developing-community-health-applications.md).
 
-The Core Framework addresses complexities like health system roles and reporting hierarchies, and its features are flexible enough to support a range of health programs and local care provider workflows.  
+The Core Framework addresses complexities like health system roles and reporting hierarchies, and its features are flexible enough to support a range of health programs and local care provider workflows.
 
-Mobile and web applications built with the Core Framework support a team-based approach to healthcare delivery and management. Health workers can use SMS messages or mobile applications to submit health data that can then be viewed and exported using a web application. These web applications are fully responsive with a mobile-first design, and support localization using any written language. They can be installed locally or in the cloud by setting up the individual components or as a Docker container. 
+Mobile and web applications built with the Core Framework support a team-based approach to healthcare delivery and management. Health workers can use SMS messages or mobile applications to submit health data that can then be viewed and exported using a web application. These web applications are fully responsive with a mobile-first design, and support localization using any written language. They can be installed locally or in the cloud by setting up the individual components or as a Docker container.
 
 For more information about Medic Mobile's architecture and how the pieces fit together, see [Architecture Overview](https://github.com/medic/medic-docs/blob/master/development/architecture.md).
 For more information about the format of docs in the database, see [Database Schema](https://github.com/medic/medic-docs/blob/master/development/db-schema.md).
@@ -213,7 +213,7 @@ They live in the `tests` directories of each app. Run them with grunt: `grunt un
 
 ### End to End tests
 
-They live in [tests](tests). Run them with grunt: `grunt e2e`.
+They live in [tests](tests). Run them with grunt: `grunt e2e`. Docker is required (it should be available on the command line as `docker`).
 
 ### API integration tests
 
@@ -231,7 +231,7 @@ To build reference documentation into a local folder `jsdoc-docs`: `grunt build-
 
 This app is highly configurable and can be modified to suit your needs. Read the guide for [developing community health applications](https://github.com/medic/medic-docs/blob/master/configuration/developing-community-health-applications.md) if you would like to customize your application further.
 
-This repo includes a standard configuration as a useful starting point. It is located at [./config/standard](https://github.com/medic/medic/tree/master/config/standard). 
+This repo includes a standard configuration as a useful starting point. It is located at [./config/standard](https://github.com/medic/medic/tree/master/config/standard).
 
 Configuration is performed using [Medic Configurer](https://github.com/medic/medic-conf). `medic-conf` expects a particular structure (seen in the standard config above). It compiles forms and configuration into the required formats, as well as uploading that configuration and performing other tasks.
 
@@ -248,9 +248,9 @@ Code is automatically published via [Travis CI](https://travis-ci.org/medic/medi
 
 ## Contributing
 
-The Core Framework of the [Community Health Toolkit](https://communityhealthtoolkit.org) is powered by people like you. We appreciate your contributions, and are dedicated to supporting the developers who improve our tools whenever possible. 
+The Core Framework of the [Community Health Toolkit](https://communityhealthtoolkit.org) is powered by people like you. We appreciate your contributions, and are dedicated to supporting the developers who improve our tools whenever possible.
 
-First time contributor? Issues labeled [help wanted](https://github.com/medic/medic/labels/Help%20wanted) are a great place to start. 
+First time contributor? Issues labeled [help wanted](https://github.com/medic/medic/labels/Help%20wanted) are a great place to start.
 
 Looking for other ways to help? You can also:
 * Improve documentation. Check out our style guide [here](https://github.com/medic/medic-docs/blob/master/development/docs-style-guide.md)
@@ -258,7 +258,7 @@ Looking for other ways to help? You can also:
 * Try to reproduce issues and help with troubleshooting
 * Or share a new idea or question with us!
 
-The easiest ways to get in touch are by raising issues in the [medic Github repo](https://github.com/medic/medic/issues) or [joining our Slack channel](https://communityhealthtoolkit.org/slack). You can even [request access](mailto:info@communityhealthtoolkit.org) to our community forum. 
+The easiest ways to get in touch are by raising issues in the [medic Github repo](https://github.com/medic/medic/issues) or [joining our Slack channel](https://communityhealthtoolkit.org/slack). You can even [request access](mailto:info@communityhealthtoolkit.org) to our community forum.
 
 For more information check out our [contributor guidelines](CONTRIBUTING.md).
 

--- a/shared-libs/server-checks/src/checks.js
+++ b/shared-libs/server-checks/src/checks.js
@@ -28,6 +28,8 @@ const envVarsCheck = () => {
   envValueAndExample.forEach(([envconst, example]) => {
     if (!process.env[envconst]) {
       failures.push(`${envconst} must be set. For example: ${envconst}=${example}`);
+    } else {
+      console.log(envconst, process.env[envconst]);
     }
   });
 

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -9,10 +9,13 @@ module.exports = {
   API_HOST: 'localhost',
 
   // connection information for the couchdb instance
-  COUCH_PORT: 5984,
+  // locally we spin up a different CouchDB for e2e tests
+  COUCH_PORT: IS_TRAVIS ? 5984 : 4984,
   COUCH_HOST: 'localhost',
 
   // test database to avoid writing to the dev db
+  // TODO: we don't need to do this anymore since it's in its own docker container
+  // HOWEVER, we have dodgy hard-coded work in login.js around medic-test
   DB_NAME: 'medic-test',
   MAIN_DDOC_NAME: 'medic',
 
@@ -22,6 +25,6 @@ module.exports = {
   DEFAULT_USER_CONTACT_DOC: {
     _id: 'e2e_contact_test_id',
     type: 'person',
-    reported_date: 1541679811408, 
+    reported_date: 1541679811408,
   },
 };

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -222,7 +222,7 @@ const deleteAll = (except = []) => {
             console.log(`Deleted docs: ${JSON.stringify(response)}`);
           }
         }),
-        sentinel.allDocs({keys: infoIds})
+        module.exports.sentinelDb.allDocs({keys: infoIds})
           .then(results => {
             const deletes = results.rows
               .filter(row => row.value) // Not already deleted
@@ -232,7 +232,7 @@ const deleteAll = (except = []) => {
                 _deleted: true
               }));
 
-            return sentinel.bulkDocs(deletes);
+            return module.exports.sentinelDb.bulkDocs(deletes);
           }).then(response => {
           if (e2eDebug) {
             console.log(`Deleted sentinel docs: ${JSON.stringify(response)}`);


### PR DESCRIPTION
Uses docker and tmpfs mounting to provide a completely fresh CouchDB instance to
locally run e2e tests.

Travis is not affected.

This stops e2e results from polluting your CouchDB, including your `_users`
database.

CouchDB is left running under 4984 so you can inspect the DB if you wish. It
will get cleaned out on computer restart or on the next e2e call.

Additionally e2e tests will probably run faster locally as they are now
effectively running CouchDB out of a RAM drive.

It requires Docker to be installed in such a way that `docker` is available on
the command line.
