### PR TITLE
Listen for close on xsltproc child process

### DIFF
--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -27,11 +27,14 @@ const transform = (formXml, stylesheet) => {
     xsltproc.stdin.setEncoding('utf-8');
     xsltproc.stdin.write(formXml);
     xsltproc.stdin.end();
-    xsltproc.on('exit', code => {
-      if (code !== 0 || stderr.length) {
+    xsltproc.on('close', (code, signal) => {
+      if (code !== 0 || signal || stderr.length) {
         logger.error('xsltproc stderr output: ');
         logger.error(stderr);
-        return reject(new Error(`Error transforming xml, xsltproc returned code "${code}"`));
+        return reject(new Error(`Error transforming xml. xsltproc returned code "${code}", and signal "${signal}"`));
+      }
+      if (!stdout) {
+        return reject(new Error(`Error transforming xml. xsltproc returned no error but no output.`));
       }
       resolve(stdout);
     });

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -81,7 +81,7 @@ describe('generate-xform service', () => {
       runTest('simple', 'some error')
         .then(() => done(new Error('expected error to be thrown')))
         .catch(err => {
-          expect(err.message).to.equal(`Error transforming xml, xsltproc returned code "100"`);
+          expect(err.message).to.equal(`Error transforming xml. xsltproc returned code "100", and signal "undefined"`);
           done();
         });
     });

--- a/tests/e2e/sentinel/schedules/reminders.spec.js
+++ b/tests/e2e/sentinel/schedules/reminders.spec.js
@@ -126,7 +126,7 @@ const start = moment().utc();
 // at 3:30 on Monday
 // because the later.schedule results are dependent on when the test runs, we can't use "every x seconds" expressions
 // and expect the same results
-const momentToTextExpression = date => `at ${date.format('hh:mm')} on ${date.format('ddd')}`;
+const momentToTextExpression = date => `at ${date.format('HH:mm')} on ${date.format('ddd')}`;
 
 const remindersConfig = [
   {


### PR DESCRIPTION
Under load the 'exit' event fires before the child process has
finished writing to stdout. The 'close' event isn't fired until the
streams are closed.

medic/medic#5961

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
