### PR TITLE
Fixes LineageModelGenerator for offline users

### DIFF
--- a/webapp/src/js/services/lineage-model-generator.js
+++ b/webapp/src/js/services/lineage-model-generator.js
@@ -65,6 +65,9 @@ angular.module('inboxServices').factory('LineageModelGenerator',
               // The lineage should also be hydrated when merge is true
               const deepCopy = obj => JSON.parse(JSON.stringify(obj));
               for (let i = result.lineage.length - 2; i >= 0; i--) {
+                if (!result.lineage[i] || !result.lineage[i+1]) {
+                  continue;
+                }
                 result.lineage[i].parent = deepCopy(result.lineage[i+1]);
               }
             } else {

--- a/webapp/tests/karma/unit/services/lineage-model-generator.js
+++ b/webapp/tests/karma/unit/services/lineage-model-generator.js
@@ -175,6 +175,25 @@ describe('LineageModelGenerator service', () => {
       });
     });
 
+    it('should merge lineage with undefined members v2', () => {
+      const contact = { _id: 'a', name: '1', parent: { _id: 'b', parent: { _id: 'c', parent: { _id: 'd' } } } };
+      const parent = { _id: 'b', name: '2', parent: { _id: 'c', parent: { _id: 'd' } } };
+      dbQuery.resolves({ rows: [{ doc: contact, key: ['a', 0] }, { doc: parent,  key: ['a', 1] }, { key: ['a', 2] }, { key: ['a', 3], doc: { _id: 'd', name: '4' } }] });
+      const expected = {
+        _id: 'a',
+        doc: {
+          _id: 'a',
+          name: '1',
+          parent: { _id: 'b', name: '2', parent: { _id: 'c', parent: { _id: 'd', name: '4' } } },
+        },
+        lineage: [{ _id: 'b', name: '2', parent: { _id: 'c', parent: { _id: 'd' } } }, undefined, { _id: 'd', name: '4' }]
+      };
+      return service.contact('a', { merge: true }).then(actual => {
+        console.log(JSON.stringify(actual, null, 2));
+        chai.expect(actual).to.deep.equal(expected);
+      });
+    });
+
     it('does not merge lineage without merge', () => {
       const contact = { _id: 'a', name: '1', parent: { _id: 'b', parent: { _id: 'c' } } };
       const parent = { _id: 'b', name: '2' };


### PR DESCRIPTION
# Description

Fixes LineageModelGenerator for offline users by not attempting to merge `undefined` (not replicated) parents.

medic/medic#5959

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
