### PR TITLE
Adds option to overwrite settings to api update settings endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -178,6 +178,7 @@ Returns the settings in JSON format.
 
 | Variable | Description                                                                                             |
 | -------- | ------------------------------------------------------------------------------------------------------- |
+| overwrite  | Whether to replace settings document with input document. If both replace and overwite are set, then it overwites only. Defaults to replace. |
 | replace  | Whether to replace existing settings for the given properties or to merge. Defaults to false (merging). |
 
 # Export

--- a/api/src/controllers/settings.js
+++ b/api/src/controllers/settings.js
@@ -42,7 +42,8 @@ module.exports = {
       })
       .then(() => {
         const replace = req.query && req.query.replace;
-        return settingsService.update(req.body, replace);
+        const overwrite = req.query && req.query.overwrite;
+        return settingsService.update(req.body, replace, overwrite);
       })
       .then(() => {
         res.json({ success: true });

--- a/api/src/services/settings.js
+++ b/api/src/services/settings.js
@@ -46,9 +46,14 @@ module.exports = {
       });
   },
   /**
-   * @param replace If true, recursively merges the properties.
+   * Process a request to either replace, overwrite or extend existing settings. 
+   * If both replace and overwite are set, then it is assumed that only replace 
+   * is set.
+   * @param replace If true, recursively merges the properties leaving existing 
+   *                properties not in the input document intact.
+   * @param overwrite If true, replace the settings document with input document.
    */
-  update: (body, replace) => {
+  update: (body, replace, overwrite) => {
     const pathToDefaultConfig = path.resolve(environment.getExtractedResourcesPath(), 'default-docs/settings.doc.json');
     const defaultConfig = require(pathToDefaultConfig);
 
@@ -68,6 +73,8 @@ module.exports = {
 
         if (replace) {
           doReplace(doc.settings, body);
+        } else if (overwrite) {
+          doc.settings = body;
         } else {
           doExtend(doc.settings, body);
         }

--- a/api/src/services/settings.js
+++ b/api/src/services/settings.js
@@ -47,7 +47,7 @@ module.exports = {
   },
   /**
    * Process a request to either replace, overwrite or extend existing settings. 
-   * If both replace and overwite are set, then it is assumed that only replace 
+   * If both replace and overwite are set, then it is assumed that only overwite 
    * is set.
    * @param replace If true, recursively merges the properties leaving existing 
    *                properties not in the input document intact.
@@ -71,10 +71,10 @@ module.exports = {
 
         const original = JSON.stringify(doc.settings);
 
-        if (replace) {
+        if (overwrite) {
+            doc.settings = body;
+        } else if (replace) {
           doReplace(doc.settings, body);
-        } else if (overwrite) {
-          doc.settings = body;
         } else {
           doExtend(doc.settings, body);
         }

--- a/api/tests/mocha/services/settings.spec.js
+++ b/api/tests/mocha/services/settings.spec.js
@@ -13,7 +13,6 @@ let settings,
 describe('settings service', () => {
   beforeEach(function() {
     settings = { a: 'a', permissions: { b: 'b'} };
-    replace = 1;
     sinon.stub(db.medic, 'get').resolves({ settings });
 
     const resourceDirectory = path.resolve(__dirname, '../../../../build/ddocs/medic/_attachments');
@@ -25,10 +24,42 @@ describe('settings service', () => {
   });
 
   describe('update', () => {
+           it('does not overwrite if replace is set and overwrite is set', () => {
+              const update = sinon.stub(db.medic, 'put');
+              let newSettings = Object.assign({}, settings);
+              delete newSettings['c'];
+              
+              replace = 1;
+              overwrite = 1;
+              
+              return service
+              .update(newSettings, replace, overwrite)
+              .then(() => {
+                    update.callCount.should.equal(1);
+                    update.args[0][0].settings.should.deep.equal(settings);
+                    });
+              });
+  
+           it('does overwrite if replace is not set and overwrite is set', () => {
+              const update = sinon.stub(db.medic, 'put');
+              let newSettings = Object.assign({}, settings);
+              delete newSettings['c'];
+              
+              overwrite = 1;
+              
+              return service
+              .update(newSettings, replace, overwrite)
+              .then(() => {
+                    update.callCount.should.equal(1);
+                    update.args[0][0].settings.should.deep.equal(newSettings);
+                    });
+              });
+           
     it('does not update if the settings doc has not been modified when replacing', () => {
       defaults.permissions = {};
       const update = sinon.stub(db.medic, 'put');
-      
+      replace = 1;
+       
       return service
         .update(settings, replace)
         .then(() => {
@@ -39,7 +70,8 @@ describe('settings service', () => {
     it('does not update if the settings doc has not been modified when extending', () => {
       defaults.permissions = {};
       const update = sinon.stub(db.medic, 'put');
-      
+      replace = 1;
+       
       return service
         .update(settings)
         .then(() => {
@@ -52,6 +84,7 @@ describe('settings service', () => {
       const update = sinon.stub(db.medic, 'put');
       let newSettings = Object.assign({}, settings);
       newSettings.a = 'b';
+      replace = 1;
       
       return service
         .update(newSettings, replace)
@@ -66,6 +99,7 @@ describe('settings service', () => {
       const update = sinon.stub(db.medic, 'put');
       let newSettings = Object.assign({}, settings);
       newSettings.a = 'b';
+      replace = 1;
       
       return service
         .update(newSettings, replace)
@@ -78,7 +112,8 @@ describe('settings service', () => {
     it('does update if the default settings has an extra permission when replacing', () => {
       defaults.permissions = { c: 'd' };
       const update = sinon.stub(db.medic, 'put');
-      
+      replace = 1;
+       
       return service
         .update(settings, replace)
         .then(() => {
@@ -92,7 +127,8 @@ describe('settings service', () => {
     it('does update if the default settings has an extra permission when extending', () => {
       defaults.permissions = { c: 'd' };
       const update = sinon.stub(db.medic, 'put');
-      
+      replace = 1;
+       
       return service
         .update(settings, replace)
         .then(() => {

--- a/api/tests/mocha/services/settings.spec.js
+++ b/api/tests/mocha/services/settings.spec.js
@@ -8,7 +8,8 @@ const service = require('../../../src/services/settings'),
       defaults = require('../../../../build/ddocs/medic/_attachments/default-docs/settings.doc.json');
 
 let settings,
-    replace;
+    replace,
+    overwrite;
 
 describe('settings service', () => {
   beforeEach(function() {

--- a/api/tests/mocha/services/settings.spec.js
+++ b/api/tests/mocha/services/settings.spec.js
@@ -25,36 +25,34 @@ describe('settings service', () => {
   });
 
   describe('update', () => {
-           it('does replace if replace is set and overwrite is not set', () => {
-              const update = sinon.stub(db.medic, 'put');
-              let newSettings = Object.assign({}, settings);
-              delete newSettings['a'];
+    it('does replace if replace is set and overwrite is not set', () => {
+      const update = sinon.stub(db.medic, 'put');
+      let newSettings = Object.assign({}, settings);
+      delete newSettings['a'];
+      replace = 1;
               
-              replace = 1;
-              
-              return service
-              .update(newSettings, replace, overwrite)
-              .then(() => {
-                    update.callCount.should.equal(1);
-                    update.args[0][0].settings.should.deep.equal(settings);
-                    });
-              });
+      return service
+        .update(newSettings, replace, overwrite)
+        .then(() => {
+          update.callCount.should.equal(1);
+          update.args[0][0].settings.should.deep.equal(settings);
+        });
+    });
            
-           it('does overwrite if replace is set and overwrite is set', () => {
-              const update = sinon.stub(db.medic, 'put');
-              let newSettings = Object.assign({}, settings);
-              delete newSettings['a'];
+    it('does overwrite if replace is set and overwrite is set', () => {
+      const update = sinon.stub(db.medic, 'put');
+      let newSettings = Object.assign({}, settings);
+      delete newSettings['a'];
+      replace = 1;
+      overwrite = 1;
               
-              replace = 1;
-              overwrite = 1;
-              
-              return service
-              .update(newSettings, replace, overwrite)
-              .then(() => {
-                    update.callCount.should.equal(1);
-                    update.args[0][0].settings.should.deep.equal(newSettings);
-                    });
-              });
+      return service
+        .update(newSettings, replace, overwrite)
+        .then(() => {
+          update.callCount.should.equal(1);
+          update.args[0][0].settings.should.deep.equal(newSettings);
+        });
+    });
            
     it('does not update if the settings doc has not been modified when replacing', () => {
       defaults.permissions = {};

--- a/api/tests/mocha/services/settings.spec.js
+++ b/api/tests/mocha/services/settings.spec.js
@@ -25,13 +25,12 @@ describe('settings service', () => {
   });
 
   describe('update', () => {
-           it('does not overwrite if replace is set and overwrite is set', () => {
+           it('does replace if replace is set and overwrite is not set', () => {
               const update = sinon.stub(db.medic, 'put');
               let newSettings = Object.assign({}, settings);
-              delete newSettings['c'];
+              delete newSettings['a'];
               
               replace = 1;
-              overwrite = 1;
               
               return service
               .update(newSettings, replace, overwrite)
@@ -40,12 +39,13 @@ describe('settings service', () => {
                     update.args[0][0].settings.should.deep.equal(settings);
                     });
               });
-  
-           it('does overwrite if replace is not set and overwrite is set', () => {
+           
+           it('does overwrite if replace is set and overwrite is set', () => {
               const update = sinon.stub(db.medic, 'put');
               let newSettings = Object.assign({}, settings);
-              delete newSettings['c'];
+              delete newSettings['a'];
               
+              replace = 1;
               overwrite = 1;
               
               return service


### PR DESCRIPTION
# Description

Adds option to overwrite settings to api update settings endpoint

medic/medic#5940

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
