### PR TITLE
Catch and downgrade interpolation syntax errors 

### DIFF
--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -140,7 +140,7 @@ const createReduxLoggerConfig = Selectors => ({
     $urlRouterProvider.when('/messages/{uuid:[^:]*}', '/messages/contact:{uuid}');
     $translateProvider.useLoader('TranslationLoader', {});
     $translateProvider.useSanitizeValueStrategy('escape');
-    $translateProvider.addInterpolation('$translateMessageFormatInterpolation');
+    $translateProvider.addInterpolation('TranslationMessageFormatInterpolation');
     $translateProvider.addInterpolation('TranslationNullInterpolation');
     $translateProvider.useMissingTranslationHandlerLog();
     $compileProvider.aHrefSanitizationWhitelist(

--- a/webapp/src/js/services/index.js
+++ b/webapp/src/js/services/index.js
@@ -85,6 +85,7 @@
   require('./translate');
   require('./translate-from');
   require('./translation-loader');
+  require('./translation-message-format-interpolation');
   require('./translation-null-interpolation');
   require('./uhc-settings');
   require('./unread-records');

--- a/webapp/src/js/services/translation-message-format-interpolation.js
+++ b/webapp/src/js/services/translation-message-format-interpolation.js
@@ -2,7 +2,10 @@
  * Module to intercept and ignore certain interpolation errors
  * @see https://github.com/medic/medic/issues/5863
  */
-angular.module('inboxServices').factory('TranslationMessageFormatInterpolation', function($log, $translateMessageFormatInterpolation) {
+angular.module('inboxServices').factory('TranslationMessageFormatInterpolation', function(
+  $log,
+  $translateMessageFormatInterpolation
+) {
   return {
     setLocale: $translateMessageFormatInterpolation.setLocale,
     getInterpolationIdentifier: $translateMessageFormatInterpolation.getInterpolationIdentifier,

--- a/webapp/src/js/services/translation-message-format-interpolation.js
+++ b/webapp/src/js/services/translation-message-format-interpolation.js
@@ -1,0 +1,22 @@
+/**
+ * Module to intercept and ignore certain interpolation errors
+ * @see https://github.com/medic/medic/issues/5863
+ */
+angular.module('inboxServices').factory('TranslationMessageFormatInterpolation', function($log, $translateMessageFormatInterpolation) {
+  return {
+    setLocale: $translateMessageFormatInterpolation.setLocale,
+    getInterpolationIdentifier: $translateMessageFormatInterpolation.getInterpolationIdentifier,
+    interpolate: function (string, interpolationParams, context, sanitizeStrategy) {
+      try {
+        return $translateMessageFormatInterpolation.interpolate(string, interpolationParams, context, sanitizeStrategy);
+      } catch (e) {
+        if (e.name === 'SyntaxError') {
+          // indicates a poorly configured translation value, should not be fatal
+          $log.warn(`Error interpolating "${string}"`, e);
+        } else {
+          $log.error(e);
+        }
+      }
+    }
+  };
+});


### PR DESCRIPTION
# Description

Uncaught errors create feedback docs so can be a performance
issue when created in large numbers. This code catches and warns
about syntax errors which are probably a configuration issue.

#5863

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
