### PR TITLE
Reduce filter width on small screens

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1265,11 +1265,8 @@ a.fa:hover {
     .navigation .mm-button {
       vertical-align: top;
     }
-    .dropdown {
-      max-width: 80px;
-      &.analytics-module {
-        width: 80px;
-      }
+    .dropdown.analytics-module {
+      width: 80px;
     }
     .mm-button-text {
       width: 0;
@@ -1463,9 +1460,8 @@ a.fa:hover {
   .logo {
     display: none;
   }
-  .filters .mm-button-icon {
-    font-size: @font-medium;
-    padding-top: 10px;
+  .filters .filter {
+    width: 17%;
   }
   .header {
     .tabs {


### PR DESCRIPTION
The refresh button was being pushed off the screen. This shrinks
the filters slightly so it fits nicely.

Also removes some code which was making the icons unnecessarily
small.

medic/medic#5951

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
