### PR TITLE
Limits size of resource icons in card

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -538,8 +538,8 @@ body {
     vertical-align: middle;
   }
   .card .resource-icon img {
-    max-width: 30px;
-    max-height: 30px;
+    width: @icon-small;
+    height: @icon-small;
   }
   .card.children .row a:hover {
     border-color: @contacts-color;

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -537,6 +537,10 @@ body {
     font-size: 12px;
     vertical-align: middle;
   }
+  .card .resource-icon img {
+    max-width: 30px;
+    max-height: 30px;
+  }
   .card.children .row a:hover {
     border-color: @contacts-color;
   }


### PR DESCRIPTION
# Description

Limits size of resource icons in card to 30x30

<img width="735" alt="Screen Shot 2019-10-09 at 1 00 03 PM" src="https://user-images.githubusercontent.com/1445164/66504049-598e4200-ea96-11e9-84b8-3ea232e7d6dc.png">

medic/medic#5963

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
