### PR TITLE
Catch db deleted errors.

### DIFF
--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -201,10 +201,12 @@ module.exports = {
     } catch (err) {
       return serverUtils.error(err, req, res);
     }
-    return getAllowedDocIds(userCtx).then(docIds => res.json({
-      total_docs: docIds.length,
-      warn: docIds.length >= usersService.DOC_IDS_WARN_LIMIT,
-      limit: usersService.DOC_IDS_WARN_LIMIT
-    }));
+    return getAllowedDocIds(userCtx)
+      .then(docIds => res.json({
+        total_docs: docIds.length,
+        warn: docIds.length >= usersService.DOC_IDS_WARN_LIMIT,
+        limit: usersService.DOC_IDS_WARN_LIMIT
+      }))
+      .catch(err => serverUtils.error(err, req, res));
   },
 };

--- a/api/src/services/purged-docs.js
+++ b/api/src/services/purged-docs.js
@@ -11,22 +11,19 @@ const DB_NOT_FOUND_ERROR = new Error('not_found');
 const purgeDbs = {};
 const getPurgeDb = (roles) => {
   const hash = purgingUtils.getRoleHash(roles);
-  if (purgeDbs[hash]) {
-    return Promise.resolve(purgeDbs[hash]);
-  }
-
   const dbName = purgingUtils.getPurgeDbName(environment.db, hash);
   return db.exists(dbName).then(exists => {
     if (!exists) {
+      delete purgeDbs[hash];
       throw DB_NOT_FOUND_ERROR;
     }
-    purgeDbs[hash] = db.get(dbName);
+    purgeDbs[hash] = purgeDbs[hash] || db.get(dbName);
     return purgeDbs[hash];
   });
 };
 
 const catchDbNotFoundError = (err) => {
-  if (err !== DB_NOT_FOUND_ERROR) {
+  if (err !== DB_NOT_FOUND_ERROR && err.status !== 404) {
     throw err;
   }
 };

--- a/api/src/services/purged-docs.js
+++ b/api/src/services/purged-docs.js
@@ -8,22 +8,19 @@ const utils = require('../controllers/utils');
 
 const CACHE_NAME = 'purged-docs';
 const DB_NOT_FOUND_ERROR = new Error('not_found');
-const purgeDbs = {};
 const getPurgeDb = (roles) => {
   const hash = purgingUtils.getRoleHash(roles);
   const dbName = purgingUtils.getPurgeDbName(environment.db, hash);
   return db.exists(dbName).then(exists => {
     if (!exists) {
-      delete purgeDbs[hash];
       throw DB_NOT_FOUND_ERROR;
     }
-    purgeDbs[hash] = purgeDbs[hash] || db.get(dbName);
-    return purgeDbs[hash];
+    return db.get(dbName, { skip_setup: true });
   });
 };
 
 const catchDbNotFoundError = (err) => {
-  if (err !== DB_NOT_FOUND_ERROR && err.status !== 404) {
+  if (err !== DB_NOT_FOUND_ERROR) {
     throw err;
   }
 };

--- a/api/tests/mocha/services/purged-docs.js
+++ b/api/tests/mocha/services/purged-docs.js
@@ -184,7 +184,7 @@ describe('Purged Docs service', () => {
           return service.getPurgedIds(['a', 'b'], ['4', '5', '6']);
         })
         .then(result => {
-          // second time we all `db.exists` it returns false
+          // second time we call `db.exists` it returns false
           chai.expect(result).to.deep.equal([]);
           chai.expect(db.exists.callCount).to.equal(2);
           const purgeDbs = service.__get__('purgeDbs');


### PR DESCRIPTION
# Description

Always check if the purge DB exists before querying it and delete the reference when it was deleted. 
Optionally also catch 404s from the _changes requests.
Fixes `users-info` not handling errors. 

medic/medic#6012

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
