### PR TITLE
Disable transitions in e2e tests.

### DIFF
--- a/tests/conf.js
+++ b/tests/conf.js
@@ -123,11 +123,13 @@ const login = browser => {
 
 const setupSettings = () => {
   const pathToDefaultAppSettings = path.join(__dirname, './config.default.json');
-  const defaultAppSettings = fs.readFileSync(pathToDefaultAppSettings).toString();
+  const defaultAppSettings = JSON.parse(fs.readFileSync(pathToDefaultAppSettings).toString());
+  defaultAppSettings.transitions = {};
+
   return utils.request({
     path: '/api/v1/settings?replace=1',
     method: 'PUT',
-    body: defaultAppSettings,
+    body: JSON.stringify(defaultAppSettings),
     headers: { 'Content-Type': 'application/json' },
   });
 };


### PR DESCRIPTION
# Description

Disables default config transitions in e2e tests.
PR set to merge into `6016-anc-app-targets` which adds transitions to default config. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
